### PR TITLE
fix: decouple per-call system prompt from provider default

### DIFF
--- a/src/maestro/providers/anthropic.py
+++ b/src/maestro/providers/anthropic.py
@@ -33,20 +33,26 @@ class AnthropicProvider(LLMProvider):
         # Initialise the SDK client once — reused for all calls
         self._client = anthropic.Anthropic(api_key=api_key)
 
-    def complete(self, prompt: str, config: RunConfig) -> RunResult:
+    def complete(
+        self,
+        prompt: str,
+        config: RunConfig,
+        system_prompt: str | None = None,
+    ) -> RunResult:
         """
         Call the Anthropic messages endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
         """
 
         start_ms = time.monotonic()
+        effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
         try:
             response = self._client.messages.create(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
                 temperature=self.TEMPERATURE,
-                system=self.SYSTEM_PROMPT,
+                system=effective_system,
                 messages=[
                     {"role": "user", "content": prompt},
                 ],

--- a/src/maestro/providers/base.py
+++ b/src/maestro/providers/base.py
@@ -23,9 +23,19 @@ class LLMProvider(ABC):
         self.pricing = pricing
 
     @abstractmethod
-    def complete(self, prompt: str, config: RunConfig) -> RunResult:
+    def complete(
+        self,
+        prompt: str,
+        config: RunConfig,
+        system_prompt: str | None = None,
+    ) -> RunResult:
         """
         Send a prompt to the LLM and return a fully populated RunResult.
+
+        If system_prompt is None, the provider falls back to its own default
+        SYSTEM_PROMPT class attribute. Strategies that need a different system
+        identity for a given call (e.g. SOP intermediate steps requesting JSON
+        instead of Mermaid) pass an explicit string.
 
         Implementations must:
         - Measure wall-clock duration_ms

--- a/src/maestro/providers/openai.py
+++ b/src/maestro/providers/openai.py
@@ -33,13 +33,19 @@ class OpenAIProvider(LLMProvider):
         # Initialise the SDK client once — reused for all calls
         self._client = openai.OpenAI(api_key=api_key)
 
-    def complete(self, prompt: str, config: RunConfig) -> RunResult:
+    def complete(
+        self,
+        prompt: str,
+        config: RunConfig,
+        system_prompt: str | None = None,
+    ) -> RunResult:
         """
         Call the OpenAI chat completions endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
         """
 
         start_ms = time.monotonic()
+        effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
         try:
             response = self._client.chat.completions.create(
@@ -47,7 +53,7 @@ class OpenAIProvider(LLMProvider):
                 max_tokens=self.MAX_TOKENS,
                 temperature=self.TEMPERATURE,
                 messages=[
-                    {"role": "system", "content": self.SYSTEM_PROMPT},
+                    {"role": "system", "content": effective_system},
                     {"role": "user", "content": prompt},
                 ],
             )

--- a/src/maestro/strategies/sop.py
+++ b/src/maestro/strategies/sop.py
@@ -96,10 +96,19 @@ Relationships:
 # Step definitions
 # ---------------------------------------------------------------------------
 
+# System prompt for steps 1 and 2 — these expect strict JSON output, so the
+# provider's default Mermaid-only system prompt would mislead the model.
+# Step 3 generates the diagram and uses the provider's default system prompt.
+SOP_JSON_SYSTEM_PROMPT = (
+    "You are a data extraction assistant. "
+    "Respond only with valid JSON matching the schema in the user message. "
+    "Do not include any explanation, markdown fencing, or additional text."
+)
+
 STEPS = [
-    {"number": 1, "name": "extract_entities",       "prompt": STEP_1_PROMPT},
-    {"number": 2, "name": "extract_relationships",  "prompt": STEP_2_PROMPT},
-    {"number": 3, "name": "generate_mermaid",        "prompt": STEP_3_PROMPT},
+    {"number": 1, "name": "extract_entities",       "prompt": STEP_1_PROMPT, "system_prompt": SOP_JSON_SYSTEM_PROMPT},
+    {"number": 2, "name": "extract_relationships",  "prompt": STEP_2_PROMPT, "system_prompt": SOP_JSON_SYSTEM_PROMPT},
+    {"number": 3, "name": "generate_mermaid",        "prompt": STEP_3_PROMPT, "system_prompt": None},
 ]
 
 # Max retries per step before aborting the whole run
@@ -164,6 +173,7 @@ class SOPStrategy(BaseStrategy):
         for step in STEPS:
             step_num = step["number"]
             step_name = step["name"]
+            step_system_prompt = step["system_prompt"]
 
             # Build prompt with outputs from previous steps
             prompt = self._build_prompt(
@@ -172,7 +182,7 @@ class SOPStrategy(BaseStrategy):
 
             # Execute with retry
             sub, output_text = self._execute_step(
-                config, step_num, step_name, prompt
+                config, step_num, step_name, prompt, step_system_prompt,
             )
             sub_results.append(sub)
 
@@ -219,6 +229,7 @@ class SOPStrategy(BaseStrategy):
         step_number: int,
         step_name: str,
         prompt: str,
+        system_prompt: str | None,
     ) -> tuple[SubResult, str | None]:
         """
         Run one step with retry logic.
@@ -237,7 +248,7 @@ class SOPStrategy(BaseStrategy):
 
         for attempt in range(MAX_RETRIES + 1):
             # provider.complete() returns a RunResult — we extract what we need
-            result = self.provider.complete(prompt, config)
+            result = self.provider.complete(prompt, config, system_prompt=system_prompt)
 
             # Accumulate metrics from every attempt
             total_prompt_tokens += result.prompt_tokens


### PR DESCRIPTION
Add optional system_prompt parameter to LLMProvider.complete() so strategies can override the provider's default identity for individual calls. SOPStrategy now uses a JSON-extraction system prompt for steps 1 and 2 instead of inheriting the Mermaid-only default — the latent mismatch surfaced as JSON-decode failures on small models that strictly follow the system prompt over the user message.

Backwards compatible: single_agent and existing callers keep their implicit default by passing system_prompt=None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional system prompt customization for AI provider requests, enabling per-call override of default system instructions
  * Introduced specialized JSON extraction system prompts for structured data generation in multi-step processing workflows
  * Extended LLM provider API to propagate custom system prompts through execution pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->