### PR TITLE
fix(providers): update Mistral imports for mistralai>=2.4.7 SDK layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,11 @@ dependencies = [
     "pydantic>=2.13.3",
     "anthropic>=0.88",
     "openai>=2.30",
-    "mistralai>=2.4.4",
+    # 2.4.6 was a compromised release (TanStack supply-chain incident); 2.4.7+
+    # restructured the SDK layout — `Mistral` and `SDKError` moved out of the
+    # package root. Pin >=2.4.7 to enforce both: skip-the-bad-release and
+    # match-the-import-paths-this-code-uses.
+    "mistralai>=2.4.7",
     "google-genai>=1.75.0",
     "crewai>=1.6.1",
     "langgraph>=1.1.10",

--- a/src/maestro/providers/mistral.py
+++ b/src/maestro/providers/mistral.py
@@ -5,8 +5,8 @@ Wraps the Mistral chat completions API into the LLMProvider interface.
 
 import time
 
-from mistralai import Mistral
-from mistralai.models import SDKError
+from mistralai.client import Mistral
+from mistralai.client.errors import SDKError
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
@@ -15,7 +15,9 @@ from maestro.providers.base import LLMProvider
 class MistralProvider(LLMProvider):
     """
     Concrete provider for Mistral models (mistral-small, mistral-large, etc.)
-    Uses the official mistralai SDK — add 'mistralai>=1.5' to pyproject.toml.
+    Uses the official mistralai SDK (>=2.4.7). The 2.x SDK moved ``Mistral``
+    and ``SDKError`` out of the package root into ``mistralai.client`` and
+    ``mistralai.client.errors`` respectively.
     """
 
     SYSTEM_PROMPT = (


### PR DESCRIPTION
mistralai 2.4.7 restructured the SDK: `Mistral` moved from the package root to `mistralai.client`, and `SDKError` moved from `mistralai.models` to `mistralai.client.errors`. The old paths now raise ImportError (the top-level package is a PEP 420 namespace package), which broke any code path that touched `maestro.providers` — including `python -m maestro.run --dry-run` and the test suite, since `providers/__init__.py` re-exports every concrete provider eagerly.

Bumps the dependency pin to `mistralai>=2.4.7` because (a) 2.4.6 was the PyPI package compromised in the TanStack supply-chain incident and must be skipped, and (b) the new import paths only work on 2.4.7+. Also refreshes the stale `mistralai>=1.5` note in the class docstring.

Smoketested via `python -m maestro.run --dry-run` (prints the full experiment matrix including Mistral models) and a direct `MistralProvider(api_key, pricing)` construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mistral AI SDK dependency to version 2.4.7 or later for improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->