### PR TITLE
chore(tests): set up pytest framework and add SOP system_prompt regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 **M**ulti-**A**gent **E**valuation for **S**tructured **R**elational **O**utput
 
 Comparing agentic orchestration frameworks for automated relational diagram generation.
+
+## Running tests
+
+Install the dev extras and run pytest from the project root:
+
+```bash
+pip install -e ".[dev]"
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,101 @@
+"""
+Shared pytest fixtures for the MAESTRO test suite.
+
+The cornerstone is ``RecordingProvider`` — a hand-rolled ``LLMProvider`` that
+captures every ``complete()`` call into a list so tests can assert on the
+arguments a strategy passed in (system_prompt, prompt, config). Using a real
+subclass instead of ``unittest.mock.Mock`` keeps the contract honest: if
+``LLMProvider.complete`` ever changes signature, the recording provider breaks
+at import time, not silently in a test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+import pytest
+
+from maestro.providers.base import LLMProvider
+from maestro.schemas import ModelPricing, RunConfig, RunResult
+
+
+@dataclass
+class RecordedCall:
+    """One captured ``provider.complete()`` invocation."""
+
+    prompt: str
+    config: RunConfig
+    system_prompt: str | None
+
+
+class RecordingProvider(LLMProvider):
+    """
+    Test double for ``LLMProvider`` that records every ``complete()`` call and
+    returns canned outputs.
+
+    Construct with ``outputs`` — a list of strings to return on successive
+    calls. Each output becomes the ``output_diagram_code`` of a successful
+    ``RunResult``. If the list is exhausted, the next call returns a failing
+    ``RunResult`` so tests fail loudly rather than hang or loop.
+
+    All captured calls are appended to ``calls`` in order.
+    """
+
+    def __init__(self, outputs: list[str] | None = None) -> None:
+        pricing = ModelPricing(
+            model="test-model",
+            input_price_per_1m=0.0,
+            output_price_per_1m=0.0,
+        )
+        super().__init__(api_key="test-key", pricing=pricing)
+        self._outputs: list[str] = list(outputs) if outputs else []
+        self.calls: list[RecordedCall] = []
+
+    def complete(
+        self,
+        prompt: str,
+        config: RunConfig,
+        system_prompt: str | None = None,
+    ) -> RunResult:
+        self.calls.append(
+            RecordedCall(prompt=prompt, config=config, system_prompt=system_prompt)
+        )
+        if not self._outputs:
+            return RunResult(
+                run_id=config.run_id,
+                output_diagram_code=None,
+                prompt_tokens=0,
+                completion_tokens=0,
+                duration_ms=0,
+                cost_usd=0.0,
+                error="RecordingProvider: no more canned outputs configured",
+            )
+        return RunResult(
+            run_id=config.run_id,
+            output_diagram_code=self._outputs.pop(0),
+            prompt_tokens=1,
+            completion_tokens=1,
+            duration_ms=0,
+            cost_usd=0.0,
+            error=None,
+        )
+
+    @property
+    def system_prompts_seen(self) -> list[str | None]:
+        """Convenience: just the system_prompt arg from each recorded call."""
+        return [c.system_prompt for c in self.calls]
+
+
+@pytest.fixture
+def recording_provider_factory():
+    """
+    Returns a callable that builds a ``RecordingProvider`` with the given
+    list of canned outputs. Use a factory (not a fixture instance) so tests
+    can choose outputs that match the steps they exercise.
+    """
+
+    def _make(outputs: list[str] | None = None) -> RecordingProvider:
+        return RecordingProvider(outputs=outputs)
+
+    return _make

--- a/tests/strategies/test_sop_system_prompt.py
+++ b/tests/strategies/test_sop_system_prompt.py
@@ -1,0 +1,87 @@
+"""
+Regression test for SOPStrategy per-step ``system_prompt`` plumbing (PR #10).
+
+The bug fixed in #10 was that ``SOPStrategy._execute_step`` was not forwarding
+the per-step ``system_prompt`` to ``provider.complete()``, so steps 1 and 2
+(which need a JSON-extraction system identity) silently fell back to the
+provider's default Mermaid system prompt. This test pins the corrected wiring.
+
+CodeRabbit originally suggested asserting on the *built user prompt*, but the
+system prompt is a separate kwarg — the assertion has to be made on the call
+captured at the provider boundary, which is what ``RecordingProvider`` records.
+"""
+
+from __future__ import annotations
+
+import json
+
+from maestro.schemas import RunConfig, Strategy, Tier
+from maestro.strategies._extraction import JSON_EXTRACTION_SYSTEM_PROMPT
+from maestro.strategies.sop import SOPStrategy
+
+
+def _valid_step1_output() -> str:
+    return json.dumps({"entities": [{"id": "e1", "name": "E1", "type": "t", "parent_id": None}]})
+
+
+def _valid_step2_output() -> str:
+    return json.dumps({"relationships": [{"id": "r1", "source": "e1", "target": "e1", "type": "t", "label": None}]})
+
+
+def test_sop_forwards_per_step_system_prompt(tmp_path, recording_provider_factory):
+    """
+    Each of the three SOP steps must pass the right ``system_prompt`` through
+    to ``provider.complete()``:
+
+    - Step 1 (extract_entities)      → JSON_EXTRACTION_SYSTEM_PROMPT
+    - Step 2 (extract_relationships) → JSON_EXTRACTION_SYSTEM_PROMPT
+    - Step 3 (generate_mermaid)      → None  (provider falls back to its default)
+
+    The mock provider returns schema-valid JSON for steps 1 and 2 so
+    ``validate_step_payload`` accepts them and there is exactly one call per
+    step (no retries).
+    """
+
+    # Minimal input JSON file the strategy can read.
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"entities": [], "relationships": []}))
+
+    # Construct an InputFile that satisfies pydantic but is otherwise unused
+    # by the strategy beyond reading ``file_path``.
+    from maestro.schemas import InputFile
+
+    input_file = InputFile(
+        example_id="test_example",
+        tier=Tier.SIMPLE,
+        entity_count=0,
+        file_path=input_path,
+        ground_truth_path=input_path,  # not read in this test
+    )
+
+    config = RunConfig(
+        strategy=Strategy.SOP_BASED,
+        model="test-model",
+        example_id="test_example",
+        tier=Tier.SIMPLE,
+        run_number=1,
+    )
+
+    provider = recording_provider_factory(
+        outputs=[
+            _valid_step1_output(),
+            _valid_step2_output(),
+            "graph TD\n  e1",  # step 3 — any non-empty string is accepted
+        ]
+    )
+    strategy = SOPStrategy(provider)
+
+    run_result, sub_results = strategy.run(input_file, config)
+
+    # Sanity: all three steps ran and the run succeeded end-to-end.
+    assert run_result.error is None, f"run errored: {run_result.error}"
+    assert len(sub_results) == 3
+    assert provider.system_prompts_seen == [
+        JSON_EXTRACTION_SYSTEM_PROMPT,
+        JSON_EXTRACTION_SYSTEM_PROMPT,
+        None,
+    ]


### PR DESCRIPTION
## Summary
- Adds the first pytest test infrastructure: `tests/` directory with `conftest.py` and a `RecordingProvider` test double that subclasses `LLMProvider` and captures every `complete()` call.
- Adds `[tool.pytest.ini_options]` to `pyproject.toml` so `pytest` runs from the project root with no editable install needed.
- Documents how to run the suite in `README.md`.
- First regression test pins `SOPStrategy._execute_step`'s per-step `system_prompt` plumbing introduced in #10: steps 1 and 2 must forward `JSON_EXTRACTION_SYSTEM_PROMPT`, step 3 must pass `None`.

Closes #<this-issue-number>

## Test plan
- [x] `./.venv/bin/python -m pytest -v` - 1 passed
- [x] Rebased on top of the MistralProvider fix (PR #<mistral-pr-number>) so eager provider imports still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with project tagline and instructions for running tests locally

* **Tests**
  * Added test fixtures and infrastructure for improved test coverage
  * Added regression test to verify system prompt handling

* **Chores**
  * Configured pytest with repository-specific test paths and import settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->