### PR TITLE
feat(db): capture runtime environment per CLI invocation for reproducibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ authors = [
 keywords = ["multi-agent", "llm", "visualization", "orchestration", "thesis"]
 
 dependencies = [
+    # When adding a runtime-relevant dep here, also add it to _LIB_WHITELIST
+    # in src/maestro/db/environment.py so its installed version is captured
+    # in run_environments.lib_versions for every experiment invocation.
+    # Pure dev tooling (pytest, ruff under [project.optional-dependencies])
+    # is exempt — it does not affect experiment results.
     # Core
     "python-dotenv>=1.2.2",
     "pydantic>=2.13.3",

--- a/src/maestro/db/__init__.py
+++ b/src/maestro/db/__init__.py
@@ -2,13 +2,21 @@
 MAESTRO — db package
 """
 
-from maestro.db.client import init_db, get_connection
-from maestro.db.queries import insert_run_config, insert_run_result, fetch_all_results
+from maestro.db.client import get_connection, init_db
+from maestro.db.environment import capture_environment
+from maestro.db.queries import (
+    fetch_all_results,
+    insert_run_config,
+    insert_run_environment,
+    insert_run_result,
+)
 
 __all__ = [
+    "capture_environment",
     "fetch_all_results",
     "get_connection",
     "init_db",
     "insert_run_config",
+    "insert_run_environment",
     "insert_run_result",
 ]

--- a/src/maestro/db/client.py
+++ b/src/maestro/db/client.py
@@ -13,14 +13,29 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 SCHEMA = """
+CREATE TABLE IF NOT EXISTS run_environments (
+    environment_id      TEXT PRIMARY KEY,
+    os                  TEXT,
+    arch                TEXT,
+    python              TEXT,
+    hostname            TEXT,
+    git_commit          TEXT,
+    git_dirty           INTEGER,
+    lib_versions        TEXT,
+    docker_image_digest TEXT,
+    captured_at         TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS run_configs (
-    run_id       TEXT PRIMARY KEY,
-    strategy     TEXT NOT NULL,
-    model        TEXT NOT NULL,
-    example_id   TEXT NOT NULL,
-    tier         INTEGER NOT NULL,
-    run_number   INTEGER NOT NULL,
-    timestamp    TEXT NOT NULL
+    run_id         TEXT PRIMARY KEY,
+    strategy       TEXT NOT NULL,
+    model          TEXT NOT NULL,
+    example_id     TEXT NOT NULL,
+    tier           INTEGER NOT NULL,
+    run_number     INTEGER NOT NULL,
+    timestamp      TEXT NOT NULL,
+    environment_id TEXT,
+    FOREIGN KEY (environment_id) REFERENCES run_environments(environment_id)
 );
 
 CREATE TABLE IF NOT EXISTS run_results (
@@ -90,12 +105,33 @@ def init_db(db_path: Path) -> None:
     """
     Create the SQLite file and tables if they don't exist.
     Safe to call on every run — no data is overwritten.
+
+    Also runs the small set of additive migrations needed to bring a
+    pre-existing database (e.g. data collected before ``run_environments``
+    was introduced) up to the current schema. Old rows keep their NULL
+    ``environment_id``; no backfill is attempted.
     """
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(db_path) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         conn.executescript(SCHEMA)
+        _migrate_add_environment_id_column(conn)
         conn.commit()
+
+
+def _migrate_add_environment_id_column(conn: sqlite3.Connection) -> None:
+    """
+    Add ``run_configs.environment_id`` to databases that predate the column.
+
+    SQLite has no portable ``ADD COLUMN IF NOT EXISTS``, so we inspect
+    ``PRAGMA table_info`` first and only issue the ALTER when the column
+    is missing. The FK is declarative-only on the new column (SQLite cannot
+    add a constrained FK via ALTER); fresh databases created by ``SCHEMA``
+    above carry the FK clause directly.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(run_configs)")}
+    if "environment_id" not in cols:
+        conn.execute("ALTER TABLE run_configs ADD COLUMN environment_id TEXT")
 
 
 @contextmanager

--- a/src/maestro/db/environment.py
+++ b/src/maestro/db/environment.py
@@ -59,7 +59,11 @@ def _git_head() -> str | None:
             timeout=5,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
+        # OSError covers FileNotFoundError (git not on PATH), PermissionError
+        # (git present but not executable) and other low-level subprocess
+        # spawn failures. The probe must never crash the experiment runner
+        # it is supposed to describe — fall back to None.
         return None
     if out.returncode != 0:
         return None
@@ -81,7 +85,11 @@ def _git_dirty() -> bool | None:
             timeout=5,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
+        # OSError covers FileNotFoundError (git not on PATH), PermissionError
+        # (git present but not executable) and other low-level subprocess
+        # spawn failures. The probe must never crash the experiment runner
+        # it is supposed to describe — fall back to None.
         return None
     if out.returncode != 0:
         return None

--- a/src/maestro/db/environment.py
+++ b/src/maestro/db/environment.py
@@ -1,0 +1,122 @@
+"""
+MAESTRO — Runtime environment capture for reproducibility.
+
+Captures a snapshot of OS, hardware, Python runtime, git state, key library
+versions and (optionally) the Docker image digest once per CLI invocation.
+The resulting ``RunEnvironment`` is persisted to the ``run_environments``
+table and its ``environment_id`` is propagated into every ``RunConfig`` that
+shares the invocation, so any future replication attempt can diagnose
+diverging numbers against the exact stack that produced the original data.
+
+Failure modes are intentionally soft: if git is unavailable, the working
+tree is detached, ``MAESTRO_IMAGE_DIGEST`` is unset, or a library is not
+installed, the field is recorded as ``None`` and the experiment continues.
+The whole point of this module is observability — it must never abort the
+run it is supposed to describe.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+
+from maestro.schemas import RunEnvironment
+
+
+# Libraries whose installed version materially changes experiment behavior.
+# Mirrors the runtime dependencies in pyproject.toml — pure dev tooling
+# (pytest, ruff) is intentionally excluded since it has no effect on the
+# numbers produced by a run.
+#
+# KEEP IN SYNC WITH pyproject.toml [project].dependencies. Adding a runtime
+# dep there and forgetting to add it here means its version silently stops
+# being recorded in run_environments.lib_versions — and the omission only
+# surfaces when a future replication attempt diverges and you wonder why
+# the env snapshot looks "complete" but is missing the smoking gun.
+_LIB_WHITELIST: tuple[str, ...] = (
+    "anthropic",
+    "openai",
+    "mistralai",
+    "google-genai",
+    "crewai",
+    "langgraph",
+    "pydantic",
+    "python-dotenv",
+)
+
+
+def _git_head() -> str | None:
+    """Return ``git rev-parse HEAD`` or ``None`` if git is unavailable."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def _git_dirty() -> bool | None:
+    """
+    Return True if the working tree has uncommitted changes, False if clean,
+    None if git status could not be determined. Tri-state on purpose: a
+    failed probe must not be silently equated with a clean tree, which
+    would produce a falsely reassuring reproducibility record.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return bool(out.stdout.strip())
+
+
+def _lib_versions() -> dict[str, str | None]:
+    """Resolve installed versions for every whitelisted library, ``None`` if absent."""
+    resolved: dict[str, str | None] = {}
+    for name in _LIB_WHITELIST:
+        try:
+            resolved[name] = version(name)
+        except PackageNotFoundError:
+            resolved[name] = None
+    return resolved
+
+
+def capture_environment(image_digest_env: str = "MAESTRO_IMAGE_DIGEST") -> RunEnvironment:
+    """
+    Snapshot the runtime environment for this CLI invocation.
+
+    ``image_digest_env`` is parameterised so tests can pass an alternative
+    variable name without mutating ``os.environ``. The default matches the
+    convention documented in the issue.
+    """
+    import os
+
+    return RunEnvironment(
+        os=platform.platform(),
+        arch=platform.machine(),
+        python=sys.version,
+        hostname=platform.node() or None,
+        git_commit=_git_head(),
+        git_dirty=_git_dirty(),
+        lib_versions=json.dumps(_lib_versions(), sort_keys=True),
+        docker_image_digest=os.environ.get(image_digest_env) or None,
+        captured_at=datetime.now(timezone.utc),
+    )

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -5,7 +5,40 @@ Insert and fetch operations for RunConfig and RunResult.
 
 import sqlite3
 
-from maestro.schemas import RunConfig, RunResult, SubResult, MetricResult
+from maestro.schemas import (
+    MetricResult,
+    RunConfig,
+    RunEnvironment,
+    RunResult,
+    SubResult,
+)
+
+
+def insert_run_environment(conn: sqlite3.Connection, env: RunEnvironment) -> None:
+    """Persist a RunEnvironment row — raises if environment_id already exists."""
+    conn.execute(
+        """
+        INSERT INTO run_environments
+            (environment_id, os, arch, python, hostname,
+             git_commit, git_dirty, lib_versions, docker_image_digest,
+             captured_at)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(env.environment_id),
+            env.os,
+            env.arch,
+            env.python,
+            env.hostname,
+            env.git_commit,
+            # SQLite has no bool; coerce explicitly so None stays None.
+            None if env.git_dirty is None else int(env.git_dirty),
+            env.lib_versions,
+            env.docker_image_digest,
+            env.captured_at.isoformat(),
+        ),
+    )
 
 
 def insert_run_config(conn: sqlite3.Connection, config: RunConfig) -> None:
@@ -13,9 +46,10 @@ def insert_run_config(conn: sqlite3.Connection, config: RunConfig) -> None:
     conn.execute(
         """
         INSERT INTO run_configs
-            (run_id, strategy, model, example_id, tier, run_number, timestamp)
+            (run_id, strategy, model, example_id, tier, run_number,
+             timestamp, environment_id)
         VALUES
-            (?, ?, ?, ?, ?, ?, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             str(config.run_id),
@@ -25,6 +59,7 @@ def insert_run_config(conn: sqlite3.Connection, config: RunConfig) -> None:
             config.tier.value,
             config.run_number,
             config.timestamp.isoformat(),
+            str(config.environment_id) if config.environment_id is not None else None,
         ),
     )
 

--- a/src/maestro/run.py
+++ b/src/maestro/run.py
@@ -54,9 +54,11 @@ from maestro.experiment_config import (
 )
 from maestro.schemas import RunConfig, Strategy, Tier
 from maestro.db.client import get_connection, init_db
+from maestro.db.environment import capture_environment
 from maestro.db.queries import (
     insert_metric_result,
     insert_run_config,
+    insert_run_environment,
     insert_run_result,
     insert_sub_result,
 )
@@ -262,6 +264,19 @@ def main():
     # Initialize DB
     init_db(DB_PATH)
 
+    # Capture the runtime environment once per invocation. Every RunConfig
+    # written below carries its environment_id so a future replication
+    # attempt can diagnose diverging numbers against the exact stack that
+    # produced the original data.
+    environment = capture_environment()
+    if environment.git_dirty:
+        print(
+            "⚠  Git working tree is dirty — uncommitted changes will not be "
+            "reproducible from this commit hash."
+        )
+    with get_connection(DB_PATH) as conn:
+        insert_run_environment(conn, environment)
+
     # Track totals for summary
     successes = 0
     failures = 0
@@ -289,6 +304,7 @@ def main():
             example_id=input_file.example_id,
             tier=input_file.tier,
             run_number=run_number,
+            environment_id=environment.environment_id,
         )
 
         # Instantiate provider and strategy

--- a/src/maestro/schemas.py
+++ b/src/maestro/schemas.py
@@ -70,13 +70,53 @@ class RunConfig(BaseModel):
     run_id is the unique key; all other fields allow grouping/filtering.
     """
 
-    run_id:      UUID     = Field(default_factory=uuid4)
-    strategy:    Strategy
-    model:       str                  # e.g. "gpt-4o", "claude-3-5-sonnet"
-    example_id:  str                  # FK to InputFile.example_id
-    tier:        Tier
-    run_number:  int                  # Repeat index within same config (1-N)
-    timestamp:   datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    run_id:         UUID     = Field(default_factory=uuid4)
+    strategy:       Strategy
+    model:          str                  # e.g. "gpt-4o", "claude-3-5-sonnet"
+    example_id:     str                  # FK to InputFile.example_id
+    tier:           Tier
+    run_number:     int                  # Repeat index within same config (1-N)
+    timestamp:      datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # FK to run_environments.environment_id. Optional because rows written
+    # before this column existed have NULL, and because env capture is best
+    # effort — a run must still be persistable if the capture helper fails.
+    environment_id: Optional[UUID] = None
+
+
+# ---------------------------------------------------------------------------
+# RunEnvironment — runtime stack snapshot, one row per CLI invocation
+# ---------------------------------------------------------------------------
+
+class RunEnvironment(BaseModel):
+    """
+    Snapshot of the runtime environment that produced a batch of runs.
+
+    One row per CLI invocation, referenced by ``RunConfig.environment_id``.
+    All fields except ``environment_id`` and ``captured_at`` are nullable
+    because the underlying probe (subprocess, env var, package import) may
+    legitimately fail — a missing field must be recorded as ``None`` rather
+    than aborting the experiment.
+    """
+
+    environment_id:      UUID = Field(default_factory=uuid4)
+
+    # Host / runtime
+    os:                  Optional[str] = None      # platform.platform()
+    arch:                Optional[str] = None      # platform.machine()
+    python:              Optional[str] = None      # sys.version
+    hostname:            Optional[str] = None      # platform.node()
+
+    # Source control
+    git_commit:          Optional[str] = None      # git rev-parse HEAD
+    git_dirty:           Optional[bool] = None     # True/False/None (probe failed)
+
+    # Dependency snapshot — JSON blob: {"anthropic": "1.2.3", "openai": None, ...}
+    lib_versions:        Optional[str] = None
+
+    # Container provenance — set by CI/CD via env var, NULL when running locally
+    docker_image_digest: Optional[str] = None
+
+    captured_at:         datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a `run_environments` table that records OS, architecture, Python version, hostname, git commit + dirty flag, key library versions and an optional Docker image digest. One row is written per `python -m maestro.run` invocation and its `environment_id` (UUID4) is propagated into every `run_configs` row produced by that invocation, so a future replication attempt can diagnose diverging numbers against the exact stack the original data was produced on.

Library whitelist matches the runtime dependencies declared in pyproject.toml (anthropic, openai, mistralai, google-genai, crewai, langgraph, pydantic, python-dotenv); missing libs are recorded as null in the JSON blob rather than crashing. `git_dirty` is tri-state (True/False/None) so a failed git probe is not silently equated with a clean tree. When the working tree is dirty the runner prints a one-line warning at startup in addition to persisting the flag.

Includes an additive migration for pre-existing databases: `init_db` inspects `PRAGMA table_info(run_configs)` and only ALTERs in the new column when it is absent. Existing rows keep NULL `environment_id`; no backfill is attempted (out of scope per the issue).

Smoketested via:
- direct `capture_environment()` call (verifies all fields populate)
- migration on a copy of `maestro.db` (65 rows preserved, column added)
- `python -m maestro.run --dry-run` (still short-circuits before capture)
- end-to-end insert + JOIN against a fresh temp DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now captures a runtime environment snapshot (platform, Python, git state, library versions, optional Docker digest) and persists it.
  * Runs are linked to their captured environment for improved reproducibility; a warning shows for uncommitted git changes.

* **Documentation**
  * Added guidance on keeping runtime-relevant dependencies in sync (dev-only tooling exempt).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->