### PR TITLE
feat(providers): retry transient SDK errors with exponential backoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "google-genai>=1.75.0",
     "crewai>=1.6.1",
     "langgraph>=1.1.10",
+    # Provider-level retry with exponential backoff (see providers/_retry.py).
+    # Already pulled in transitively by langgraph/crewai but declared
+    # explicitly so it doesn't silently disappear on a transitive bump.
+    "tenacity>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
     # Provider-level retry with exponential backoff (see providers/_retry.py).
     # Already pulled in transitively by langgraph/crewai but declared
     # explicitly so it doesn't silently disappear on a transitive bump.
-    "tenacity>=8.0",
+    # >=8.1.0: that release introduced `wait_exponential_jitter`, which
+    # _retry.py imports directly. 8.0.x lacks the symbol.
+    "tenacity>=8.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/maestro/db/client.py
+++ b/src/maestro/db/client.py
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS run_results (
     duration_ms          INTEGER NOT NULL,
     cost_usd             REAL NOT NULL,
     error                TEXT,
+    retry_count          INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (run_id) REFERENCES run_configs(run_id)
 );
 
@@ -107,15 +108,16 @@ def init_db(db_path: Path) -> None:
     Safe to call on every run — no data is overwritten.
 
     Also runs the small set of additive migrations needed to bring a
-    pre-existing database (e.g. data collected before ``run_environments``
-    was introduced) up to the current schema. Old rows keep their NULL
-    ``environment_id``; no backfill is attempted.
+    pre-existing database up to the current schema. Old rows keep their
+    NULL ``run_configs.environment_id`` and default ``run_results.retry_count
+    = 0``; no backfill is attempted.
     """
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(db_path) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         conn.executescript(SCHEMA)
         _migrate_add_environment_id_column(conn)
+        _migrate_add_retry_count_column(conn)
         conn.commit()
 
 
@@ -132,6 +134,21 @@ def _migrate_add_environment_id_column(conn: sqlite3.Connection) -> None:
     cols = {row[1] for row in conn.execute("PRAGMA table_info(run_configs)")}
     if "environment_id" not in cols:
         conn.execute("ALTER TABLE run_configs ADD COLUMN environment_id TEXT")
+
+
+def _migrate_add_retry_count_column(conn: sqlite3.Connection) -> None:
+    """
+    Add ``run_results.retry_count`` to databases that predate the column.
+
+    SQLite has no portable ``ADD COLUMN IF NOT EXISTS``, so we inspect
+    ``PRAGMA table_info`` first and only ALTER when missing. Fresh
+    databases created by ``SCHEMA`` above carry the column directly.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(run_results)")}
+    if "retry_count" not in cols:
+        conn.execute(
+            "ALTER TABLE run_results ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0"
+        )
 
 
 @contextmanager

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -70,9 +70,9 @@ def insert_run_result(conn: sqlite3.Connection, result: RunResult) -> None:
         """
         INSERT INTO run_results
             (run_id, output_diagram_code, prompt_tokens, completion_tokens,
-             duration_ms, cost_usd, error)
+             duration_ms, cost_usd, error, retry_count)
         VALUES
-            (?, ?, ?, ?, ?, ?, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             str(result.run_id),
@@ -82,6 +82,7 @@ def insert_run_result(conn: sqlite3.Connection, result: RunResult) -> None:
             result.duration_ms,
             result.cost_usd,
             result.error,
+            result.retry_count,
         ),
     )
 

--- a/src/maestro/providers/_retry.py
+++ b/src/maestro/providers/_retry.py
@@ -116,7 +116,16 @@ def call_with_retry(
     ):
         with attempt:
             stats.attempts = attempt.retry_state.attempt_number
-            return fn(), stats
+            try:
+                return fn(), stats
+            except Exception as exc:
+                # ``_log_retry`` only fires before each *sleep*, so it never
+                # sees the terminal exception (no sleep after the final
+                # attempt) and never fires at all for non-retryable errors
+                # that fail on attempt 1. Capture here so stats.last_exception
+                # always reflects whatever actually came out of fn().
+                stats.last_exception = f"{type(exc).__name__}: {exc}"
+                raise
 
     # Unreachable: ``reraise=True`` propagates the last exception out of
     # the for-loop on failure; success returns from inside the with-block.

--- a/src/maestro/providers/_retry.py
+++ b/src/maestro/providers/_retry.py
@@ -1,0 +1,109 @@
+"""
+MAESTRO — Retry-with-backoff helper shared by every provider.
+
+Why this lives in its own module:
+- The retry policy (max attempts, wait shape, what counts as retryable) is
+  experimental infrastructure, not provider-specific logic. Centralising it
+  here means tightening or loosening the policy is a single edit, not four.
+- Each provider supplies its own ``is_retryable(exc)`` predicate because
+  SDK exception hierarchies differ (anthropic has ``RateLimitError`` as a
+  subclass of ``APIStatusError``, mistralai's ``SDKError`` carries the
+  status code on ``.raw_response``, gemini's ``APIError`` exposes it on
+  ``.status``). Asking each provider to classify its own errors keeps that
+  knowledge co-located with the SDK import.
+- ``call_with_retry`` returns ``(result, RetryStats)`` rather than just the
+  result so the caller can record how many retries were needed. This signal
+  is persisted to ``run_results.retry_count`` and is useful for "do high-
+  retry calls correlate with worse quality?" analysis.
+
+Failure semantics: if ``max_attempts`` is exhausted, the *last* exception is
+re-raised so the caller's existing try/except in ``complete()`` builds a
+failed RunResult exactly as before. No silent swallowing.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+from tenacity import (
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+
+T = TypeVar("T")
+
+
+# Policy constants — tuned for thesis-scale experiments (~5000 calls per run).
+# `MAX_ATTEMPTS` includes the first call, so 5 total attempts = 4 retries.
+# Backoff is capped at 60s so a long string of 429s on one provider doesn't
+# stall the whole matrix for many minutes.
+MAX_ATTEMPTS = 5
+WAIT_INITIAL = 2.0
+WAIT_MAX     = 60.0
+
+
+@dataclass
+class RetryStats:
+    """How many attempts a call took, for persistence to run_results."""
+
+    attempts: int = 1
+    last_exception: str | None = None
+
+    @property
+    def retry_count(self) -> int:
+        """Number of *retries* (i.e. attempts beyond the first)."""
+        return max(0, self.attempts - 1)
+
+
+def call_with_retry(
+    fn: Callable[[], T],
+    *,
+    is_retryable: Callable[[BaseException], bool],
+    provider_name: str,
+    max_attempts: int = MAX_ATTEMPTS,
+    wait_initial: float = WAIT_INITIAL,
+    wait_max: float = WAIT_MAX,
+) -> tuple[T, RetryStats]:
+    """
+    Run ``fn`` with exponential-backoff-with-jitter on retryable exceptions.
+
+    ``is_retryable`` decides per exception whether to retry. Non-retryable
+    exceptions are re-raised on the first occurrence so they reach the
+    caller's existing exception handlers unchanged.
+
+    ``provider_name`` is only used in the stderr log line so a long run is
+    debuggable ("which provider is rate-limiting?").
+    """
+    stats = RetryStats()
+
+    def _log_retry(retry_state) -> None:
+        # tenacity calls this before each sleep; ``retry_state.attempt_number``
+        # is the attempt that just failed.
+        exc = retry_state.outcome.exception()
+        stats.last_exception = f"{type(exc).__name__}: {exc}"
+        sleep_for = retry_state.next_action.sleep if retry_state.next_action else 0
+        print(
+            f"  [retry] {provider_name} attempt {retry_state.attempt_number} "
+            f"failed ({type(exc).__name__}); sleeping {sleep_for:.1f}s",
+            file=sys.stderr,
+        )
+
+    for attempt in Retrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential_jitter(initial=wait_initial, max=wait_max),
+        retry=retry_if_exception(is_retryable),
+        before_sleep=_log_retry,
+        reraise=True,
+    ):
+        with attempt:
+            stats.attempts = attempt.retry_state.attempt_number
+            return fn(), stats
+
+    # Unreachable: ``reraise=True`` propagates the last exception out of
+    # the for-loop on failure; success returns from inside the with-block.
+    raise RuntimeError("call_with_retry: unreachable")

--- a/src/maestro/providers/_retry.py
+++ b/src/maestro/providers/_retry.py
@@ -18,7 +18,10 @@ Why this lives in its own module:
 
 Failure semantics: if ``max_attempts`` is exhausted, the *last* exception is
 re-raised so the caller's existing try/except in ``complete()`` builds a
-failed RunResult exactly as before. No silent swallowing.
+failed RunResult exactly as before. No silent swallowing. The caller passes
+in a ``RetryStats`` it owns; the helper mutates it in place so the attempt
+count survives the exception unwind and the failed ``RunResult`` can still
+record ``retry_count``.
 """
 
 from __future__ import annotations
@@ -65,6 +68,7 @@ def call_with_retry(
     *,
     is_retryable: Callable[[BaseException], bool],
     provider_name: str,
+    stats: RetryStats | None = None,
     max_attempts: int = MAX_ATTEMPTS,
     wait_initial: float = WAIT_INITIAL,
     wait_max: float = WAIT_MAX,
@@ -78,10 +82,20 @@ def call_with_retry(
 
     ``provider_name`` is only used in the stderr log line so a long run is
     debuggable ("which provider is rate-limiting?").
+
+    Callers that need ``retry_count`` to survive an exhausted-retries
+    exception (so the failed ``RunResult`` can still record it) should
+    pre-create a ``RetryStats`` and pass it in: the helper mutates it in
+    place, so the caller's exception handlers can read ``stats.retry_count``
+    after the helper raised. If ``stats`` is omitted, a fresh instance is
+    created — convenient for success-only callers and tests.
     """
-    stats = RetryStats()
+    if stats is None:
+        stats = RetryStats()
 
     def _log_retry(retry_state) -> None:
+        """Tenacity ``before_sleep`` hook: log the failed attempt to stderr
+        and update ``stats.last_exception`` for the caller."""
         # tenacity calls this before each sleep; ``retry_state.attempt_number``
         # is the attempt that just failed.
         exc = retry_state.outcome.exception()

--- a/src/maestro/providers/anthropic.py
+++ b/src/maestro/providers/anthropic.py
@@ -6,10 +6,21 @@ Wraps the Anthropic messages API into the LLMProvider interface.
 import time
 
 import anthropic
-from anthropic import APIError, APITimeoutError, RateLimitError
+from anthropic import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    RateLimitError,
+)
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
+from maestro.providers._retry import call_with_retry
+
+
+# See providers/openai.py for the rationale on this status set.
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 
 class AnthropicProvider(LLMProvider):
@@ -33,6 +44,15 @@ class AnthropicProvider(LLMProvider):
         # Initialise the SDK client once — reused for all calls
         self._client = anthropic.Anthropic(api_key=api_key)
 
+    @staticmethod
+    def _is_retryable(exc: BaseException) -> bool:
+        """Mirrors OpenAIProvider._is_retryable — same SDK exception shape."""
+        if isinstance(exc, (APIConnectionError, APITimeoutError, RateLimitError)):
+            return True
+        if isinstance(exc, APIStatusError):
+            return exc.status_code in _RETRYABLE_STATUS
+        return False
+
     def complete(
         self,
         prompt: str,
@@ -42,13 +62,16 @@ class AnthropicProvider(LLMProvider):
         """
         Call the Anthropic messages endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
+        Transient failures are retried with exponential backoff via
+        ``call_with_retry``; non-retryable errors fall through to the
+        handlers below on the first attempt.
         """
 
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
-        try:
-            response = self._client.messages.create(
+        def _do_call():
+            return self._client.messages.create(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
                 temperature=self.TEMPERATURE,
@@ -56,6 +79,13 @@ class AnthropicProvider(LLMProvider):
                 messages=[
                     {"role": "user", "content": prompt},
                 ],
+            )
+
+        try:
+            response, stats = call_with_retry(
+                _do_call,
+                is_retryable=self._is_retryable,
+                provider_name="anthropic",
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -76,6 +106,7 @@ class AnthropicProvider(LLMProvider):
                 cost_usd            = compute_cost(
                     prompt_tokens, completion_tokens, self.pricing
                 ),
+                retry_count         = stats.retry_count,
             )
 
         except RateLimitError as e:

--- a/src/maestro/providers/anthropic.py
+++ b/src/maestro/providers/anthropic.py
@@ -16,7 +16,7 @@ from anthropic import (
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
-from maestro.providers._retry import call_with_retry
+from maestro.providers._retry import RetryStats, call_with_retry
 
 
 # See providers/openai.py for the rationale on this status set.
@@ -70,7 +70,13 @@ class AnthropicProvider(LLMProvider):
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
+        # Owned by the caller so retry_count survives an exhausted-retries
+        # exception — the except blocks below read stats.retry_count to
+        # record it on the failed RunResult.
+        stats = RetryStats()
+
         def _do_call():
+            """The SDK call ``call_with_retry`` re-runs on transient failures."""
             return self._client.messages.create(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
@@ -82,10 +88,11 @@ class AnthropicProvider(LLMProvider):
             )
 
         try:
-            response, stats = call_with_retry(
+            response, _ = call_with_retry(
                 _do_call,
                 is_retryable=self._is_retryable,
                 provider_name="anthropic",
+                stats=stats,
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -110,23 +117,25 @@ class AnthropicProvider(LLMProvider):
             )
 
         except RateLimitError as e:
-            return self._error_result(config, start_ms, f"RateLimitError: {e}")
+            return self._error_result(config, start_ms, f"RateLimitError: {e}", stats.retry_count)
 
         except APITimeoutError as e:
-            return self._error_result(config, start_ms, f"TimeoutError: {e}")
+            return self._error_result(config, start_ms, f"TimeoutError: {e}", stats.retry_count)
 
         except APIError as e:
-            return self._error_result(config, start_ms, f"APIError: {e}")
+            return self._error_result(config, start_ms, f"APIError: {e}", stats.retry_count)
 
         except Exception as e:
             # Catch-all — unexpected failures should not crash the experiment
-            return self._error_result(config, start_ms, f"UnexpectedError: {e}")
+            return self._error_result(config, start_ms, f"UnexpectedError: {e}", stats.retry_count)
 
     def _error_result(
-        self, config: RunConfig, start_ms: float, error: str
+        self, config: RunConfig, start_ms: float, error: str, retry_count: int = 0,
     ) -> RunResult:
         """
         Build a failed RunResult with zero token counts and the error message.
+        ``retry_count`` is propagated from ``RetryStats`` so an exhausted-
+        retries failure still records how many attempts were made.
         """
         return RunResult(
             run_id              = config.run_id,
@@ -136,4 +145,5 @@ class AnthropicProvider(LLMProvider):
             duration_ms         = int((time.monotonic() - start_ms) * 1000),
             cost_usd            = 0.0,
             error               = error,
+            retry_count         = retry_count,
         )

--- a/src/maestro/providers/gemini.py
+++ b/src/maestro/providers/gemini.py
@@ -5,12 +5,18 @@ Wraps the Google Gen AI generate_content API into the LLMProvider interface.
 
 import time
 
+import httpx
 from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
+from maestro.providers._retry import call_with_retry
+
+
+# See providers/openai.py for the rationale on this status set.
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 
 class GeminiProvider(LLMProvider):
@@ -31,6 +37,20 @@ class GeminiProvider(LLMProvider):
         super().__init__(api_key, pricing)
         self._client = genai.Client(api_key=api_key)
 
+    @staticmethod
+    def _is_retryable(exc: BaseException) -> bool:
+        """
+        google-genai wraps HTTP errors in ``APIError`` (and its ``ClientError``
+        / ``ServerError`` subclasses) which carry the HTTP status on ``.code``.
+        Underlying transport errors may still leak through as raw httpx
+        connect/timeout exceptions on connection failure.
+        """
+        if isinstance(exc, (httpx.ConnectError, httpx.TimeoutException)):
+            return True
+        if isinstance(exc, genai_errors.APIError):
+            return getattr(exc, "code", None) in _RETRYABLE_STATUS
+        return False
+
     def complete(
         self,
         prompt: str,
@@ -40,13 +60,15 @@ class GeminiProvider(LLMProvider):
         """
         Call the Gemini generate_content endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
+        Transient failures are retried with exponential backoff via
+        ``call_with_retry``.
         """
 
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
-        try:
-            response = self._client.models.generate_content(
+        def _do_call():
+            return self._client.models.generate_content(
                 model=config.model,
                 contents=prompt,
                 config=genai_types.GenerateContentConfig(
@@ -54,6 +76,13 @@ class GeminiProvider(LLMProvider):
                     temperature=self.TEMPERATURE,
                     max_output_tokens=self.MAX_TOKENS,
                 ),
+            )
+
+        try:
+            response, stats = call_with_retry(
+                _do_call,
+                is_retryable=self._is_retryable,
+                provider_name="gemini",
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -79,6 +108,7 @@ class GeminiProvider(LLMProvider):
                         prompt_tokens, completion_tokens, self.pricing
                     ),
                     error=f"BlockedResponse: {e}",
+                    retry_count=stats.retry_count,
                 )
 
             return RunResult(
@@ -90,6 +120,7 @@ class GeminiProvider(LLMProvider):
                 cost_usd=compute_cost(
                     prompt_tokens, completion_tokens, self.pricing
                 ),
+                retry_count=stats.retry_count,
             )
 
         except genai_errors.APIError as e:

--- a/src/maestro/providers/gemini.py
+++ b/src/maestro/providers/gemini.py
@@ -12,7 +12,7 @@ from google.genai import types as genai_types
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
-from maestro.providers._retry import call_with_retry
+from maestro.providers._retry import RetryStats, call_with_retry
 
 
 # See providers/openai.py for the rationale on this status set.
@@ -67,7 +67,13 @@ class GeminiProvider(LLMProvider):
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
+        # Owned by the caller so retry_count survives an exhausted-retries
+        # exception — the except blocks below read stats.retry_count to
+        # record it on the failed RunResult.
+        stats = RetryStats()
+
         def _do_call():
+            """The SDK call ``call_with_retry`` re-runs on transient failures."""
             return self._client.models.generate_content(
                 model=config.model,
                 contents=prompt,
@@ -79,10 +85,11 @@ class GeminiProvider(LLMProvider):
             )
 
         try:
-            response, stats = call_with_retry(
+            response, _ = call_with_retry(
                 _do_call,
                 is_retryable=self._is_retryable,
                 provider_name="gemini",
+                stats=stats,
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -124,15 +131,19 @@ class GeminiProvider(LLMProvider):
             )
 
         except genai_errors.APIError as e:
-            return self._error_result(config, start_ms, f"APIError: {e}")
+            return self._error_result(config, start_ms, f"APIError: {e}", stats.retry_count)
 
         except Exception as e:
-            return self._error_result(config, start_ms, f"UnexpectedError: {e}")
+            return self._error_result(config, start_ms, f"UnexpectedError: {e}", stats.retry_count)
 
     def _error_result(
-        self, config: RunConfig, start_ms: float, error: str
+        self, config: RunConfig, start_ms: float, error: str, retry_count: int = 0,
     ) -> RunResult:
-        """Build a failed RunResult with zero token counts and the error message."""
+        """
+        Build a failed RunResult with zero token counts and the error message.
+        ``retry_count`` is propagated from ``RetryStats`` so an exhausted-
+        retries failure still records how many attempts were made.
+        """
         return RunResult(
             run_id=config.run_id,
             output_diagram_code=None,
@@ -141,4 +152,5 @@ class GeminiProvider(LLMProvider):
             duration_ms=int((time.monotonic() - start_ms) * 1000),
             cost_usd=0.0,
             error=error,
+            retry_count=retry_count,
         )

--- a/src/maestro/providers/mistral.py
+++ b/src/maestro/providers/mistral.py
@@ -5,11 +5,17 @@ Wraps the Mistral chat completions API into the LLMProvider interface.
 
 import time
 
+import httpx
 from mistralai.client import Mistral
-from mistralai.client.errors import SDKError
+from mistralai.client.errors import NoResponseError, SDKError
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
+from maestro.providers._retry import call_with_retry
+
+
+# See providers/openai.py for the rationale on this status set.
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 
 class MistralProvider(LLMProvider):
@@ -32,6 +38,22 @@ class MistralProvider(LLMProvider):
         super().__init__(api_key, pricing)
         self._client = Mistral(api_key=api_key)
 
+    @staticmethod
+    def _is_retryable(exc: BaseException) -> bool:
+        """
+        mistralai exposes ``SDKError`` carrying ``raw_response: httpx.Response``;
+        we read ``status_code`` from there. ``NoResponseError`` means the SDK
+        got nothing back at all — always transient. Low-level httpx network
+        errors (connect / timeout) also surface unwrapped on some failure
+        modes and are equally transient.
+        """
+        if isinstance(exc, (NoResponseError, httpx.ConnectError, httpx.TimeoutException)):
+            return True
+        if isinstance(exc, SDKError):
+            status = getattr(getattr(exc, "raw_response", None), "status_code", None)
+            return status in _RETRYABLE_STATUS
+        return False
+
     def complete(
         self,
         prompt: str,
@@ -41,13 +63,15 @@ class MistralProvider(LLMProvider):
         """
         Call the Mistral chat completions endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
+        Transient failures are retried with exponential backoff via
+        ``call_with_retry``.
         """
 
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
-        try:
-            response = self._client.chat.complete(
+        def _do_call():
+            return self._client.chat.complete(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
                 temperature=self.TEMPERATURE,
@@ -55,6 +79,13 @@ class MistralProvider(LLMProvider):
                     {"role": "system", "content": effective_system},
                     {"role": "user", "content": prompt},
                 ],
+            )
+
+        try:
+            response, stats = call_with_retry(
+                _do_call,
+                is_retryable=self._is_retryable,
+                provider_name="mistral",
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -79,6 +110,7 @@ class MistralProvider(LLMProvider):
                         prompt_tokens, completion_tokens, self.pricing
                     ),
                     error="EmptyResponse: Mistral returned no content",
+                    retry_count=stats.retry_count,
                 )
 
             return RunResult(
@@ -90,6 +122,7 @@ class MistralProvider(LLMProvider):
                 cost_usd=compute_cost(
                     prompt_tokens, completion_tokens, self.pricing
                 ),
+                retry_count=stats.retry_count,
             )
 
         except SDKError as e:

--- a/src/maestro/providers/mistral.py
+++ b/src/maestro/providers/mistral.py
@@ -11,7 +11,7 @@ from mistralai.client.errors import NoResponseError, SDKError
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
-from maestro.providers._retry import call_with_retry
+from maestro.providers._retry import RetryStats, call_with_retry
 
 
 # See providers/openai.py for the rationale on this status set.
@@ -70,7 +70,13 @@ class MistralProvider(LLMProvider):
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
+        # Owned by the caller so retry_count survives an exhausted-retries
+        # exception — the except blocks below read stats.retry_count to
+        # record it on the failed RunResult.
+        stats = RetryStats()
+
         def _do_call():
+            """The SDK call ``call_with_retry`` re-runs on transient failures."""
             return self._client.chat.complete(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
@@ -82,10 +88,11 @@ class MistralProvider(LLMProvider):
             )
 
         try:
-            response, stats = call_with_retry(
+            response, _ = call_with_retry(
                 _do_call,
                 is_retryable=self._is_retryable,
                 provider_name="mistral",
+                stats=stats,
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -126,15 +133,19 @@ class MistralProvider(LLMProvider):
             )
 
         except SDKError as e:
-            return self._error_result(config, start_ms, f"SDKError: {e}")
+            return self._error_result(config, start_ms, f"SDKError: {e}", stats.retry_count)
 
         except Exception as e:
-            return self._error_result(config, start_ms, f"UnexpectedError: {e}")
+            return self._error_result(config, start_ms, f"UnexpectedError: {e}", stats.retry_count)
 
     def _error_result(
-        self, config: RunConfig, start_ms: float, error: str
+        self, config: RunConfig, start_ms: float, error: str, retry_count: int = 0,
     ) -> RunResult:
-        """Build a failed RunResult with zero token counts and the error message."""
+        """
+        Build a failed RunResult with zero token counts and the error message.
+        ``retry_count`` is propagated from ``RetryStats`` so an exhausted-
+        retries failure still records how many attempts were made.
+        """
         return RunResult(
             run_id=config.run_id,
             output_diagram_code=None,
@@ -143,4 +154,5 @@ class MistralProvider(LLMProvider):
             duration_ms=int((time.monotonic() - start_ms) * 1000),
             cost_usd=0.0,
             error=error,
+            retry_count=retry_count,
         )

--- a/src/maestro/providers/openai.py
+++ b/src/maestro/providers/openai.py
@@ -6,10 +6,23 @@ Wraps the OpenAI chat completions API into the LLMProvider interface.
 import time
 
 import openai
-from openai import APIError, APITimeoutError, RateLimitError
+from openai import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    RateLimitError,
+)
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
+from maestro.providers._retry import call_with_retry
+
+
+# HTTP status codes that indicate a transient server-side problem worth
+# retrying. 429 (rate limit) and 5xx (server errors). 4xx other than 429 are
+# the caller's fault and will not heal themselves.
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 
 class OpenAIProvider(LLMProvider):
@@ -33,6 +46,22 @@ class OpenAIProvider(LLMProvider):
         # Initialise the SDK client once — reused for all calls
         self._client = openai.OpenAI(api_key=api_key)
 
+    @staticmethod
+    def _is_retryable(exc: BaseException) -> bool:
+        """
+        OpenAI's exception hierarchy:
+          APIError → APIStatusError → RateLimitError (+ others with .status_code)
+          APIError → APIConnectionError → APITimeoutError
+        Connection / timeout errors are always retryable. APIStatusError is
+        retryable only for 429 + 5xx; 4xx other than 429 are programmer
+        or auth errors and will not heal themselves.
+        """
+        if isinstance(exc, (APIConnectionError, APITimeoutError, RateLimitError)):
+            return True
+        if isinstance(exc, APIStatusError):
+            return exc.status_code in _RETRYABLE_STATUS
+        return False
+
     def complete(
         self,
         prompt: str,
@@ -42,13 +71,16 @@ class OpenAIProvider(LLMProvider):
         """
         Call the OpenAI chat completions endpoint and return a RunResult.
         Never raises — all exceptions are captured into RunResult.error.
+        Transient failures (429, 5xx, timeouts, connection errors) are
+        retried with exponential backoff via ``call_with_retry``; the final
+        attempt's exception falls through to the handlers below.
         """
 
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
-        try:
-            response = self._client.chat.completions.create(
+        def _do_call():
+            return self._client.chat.completions.create(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
                 temperature=self.TEMPERATURE,
@@ -56,6 +88,13 @@ class OpenAIProvider(LLMProvider):
                     {"role": "system", "content": effective_system},
                     {"role": "user", "content": prompt},
                 ],
+            )
+
+        try:
+            response, stats = call_with_retry(
+                _do_call,
+                is_retryable=self._is_retryable,
+                provider_name="openai",
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -76,6 +115,7 @@ class OpenAIProvider(LLMProvider):
                 cost_usd=compute_cost(
                     prompt_tokens, completion_tokens, self.pricing
                 ),
+                retry_count=stats.retry_count,
             )
 
         except RateLimitError as e:

--- a/src/maestro/providers/openai.py
+++ b/src/maestro/providers/openai.py
@@ -16,7 +16,7 @@ from openai import (
 
 from maestro.schemas import ModelPricing, RunConfig, RunResult, compute_cost
 from maestro.providers.base import LLMProvider
-from maestro.providers._retry import call_with_retry
+from maestro.providers._retry import RetryStats, call_with_retry
 
 
 # HTTP status codes that indicate a transient server-side problem worth
@@ -79,7 +79,13 @@ class OpenAIProvider(LLMProvider):
         start_ms = time.monotonic()
         effective_system = system_prompt if system_prompt is not None else self.SYSTEM_PROMPT
 
+        # Owned by the caller so retry_count survives an exhausted-retries
+        # exception — the except blocks below read stats.retry_count to
+        # record it on the failed RunResult.
+        stats = RetryStats()
+
         def _do_call():
+            """The SDK call ``call_with_retry`` re-runs on transient failures."""
             return self._client.chat.completions.create(
                 model=config.model,
                 max_tokens=self.MAX_TOKENS,
@@ -91,10 +97,11 @@ class OpenAIProvider(LLMProvider):
             )
 
         try:
-            response, stats = call_with_retry(
+            response, _ = call_with_retry(
                 _do_call,
                 is_retryable=self._is_retryable,
                 provider_name="openai",
+                stats=stats,
             )
 
             duration_ms = int((time.monotonic() - start_ms) * 1000)
@@ -119,23 +126,25 @@ class OpenAIProvider(LLMProvider):
             )
 
         except RateLimitError as e:
-            return self._error_result(config, start_ms, f"RateLimitError: {e}")
+            return self._error_result(config, start_ms, f"RateLimitError: {e}", stats.retry_count)
 
         except APITimeoutError as e:
-            return self._error_result(config, start_ms, f"TimeoutError: {e}")
+            return self._error_result(config, start_ms, f"TimeoutError: {e}", stats.retry_count)
 
         except APIError as e:
-            return self._error_result(config, start_ms, f"APIError: {e}")
+            return self._error_result(config, start_ms, f"APIError: {e}", stats.retry_count)
 
         except Exception as e:
             # Catch-all — unexpected failures should not crash the experiment
-            return self._error_result(config, start_ms, f"UnexpectedError: {e}")
+            return self._error_result(config, start_ms, f"UnexpectedError: {e}", stats.retry_count)
 
     def _error_result(
-        self, config: RunConfig, start_ms: float, error: str
+        self, config: RunConfig, start_ms: float, error: str, retry_count: int = 0,
     ) -> RunResult:
         """
         Build a failed RunResult with zero token counts and the error message.
+        ``retry_count`` is propagated from ``RetryStats`` so an exhausted-
+        retries failure still records how many attempts were made.
         """
         return RunResult(
             run_id=config.run_id,
@@ -145,4 +154,5 @@ class OpenAIProvider(LLMProvider):
             duration_ms=int((time.monotonic() - start_ms) * 1000),
             cost_usd=0.0,
             error=error,
+            retry_count=retry_count,
         )

--- a/src/maestro/schemas.py
+++ b/src/maestro/schemas.py
@@ -162,6 +162,10 @@ class RunResult(BaseModel):
     # Error — None if successful, exception message otherwise
     error:                Optional[str] = None
 
+    # Number of *retries* the underlying provider call needed (0 = first
+    # attempt worked). Mirrors SubResult.retry_count for top-level runs.
+    retry_count:          int = 0
+
     @computed_field
     @property
     def total_tokens(self) -> int:


### PR DESCRIPTION
## Summary
- Wraps every provider's SDK call in `call_with_retry` (tenacity-backed) so 429s, 5xx and connection blips are retried instead of recorded as permanent failures.
- Each provider classifies its own SDK's exception hierarchy via a static `_is_retryable` method. 4xx other than 429 short-circuits on the first attempt.
- Policy: 5 attempts max, exponential backoff with jitter, capped at 60s, logged to stderr. Centralised in `providers/_retry.py`.
- Adds `RunResult.retry_count` + `run_results.retry_count` column (additive migration). Mirrors `SubResult.retry_count`.
- Explicit `tenacity>=8.0` pin (currently transitive via langgraph/crewai).

Closes #<issue number>

## Test plan
- [x] `pytest -v` — 1 passed (rebased on top of test-infra + env-capture PRs)
- [x] Retry helper: success-first-try, retry-then-succeed, non-retryable (immediate raise), exhaustion (last exception re-raised)
- [x] Per-provider classification: 429/500/timeout/connect retry; 400/401/403 + generic exceptions don't
- [x] Migration on copy of maestro.db: 65 rows preserved, both `environment_id` and `retry_count` columns added correctly chained
- [x] `python -m maestro.run --dry-run` — 80-row matrix prints, no import errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry with exponential backoff for transient provider errors across AI providers.
  * Run results now include a retry count so you can see how many attempts were made.

* **Chores**
  * Project configuration updated to ensure retry support is available.
  * Database schema and migrations updated to store retry counts for existing and future runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->