### PR TITLE
refactor(strategies): consolidate _file_error/_abort into BaseStrategy._error_result

### DIFF
--- a/src/maestro/strategies/base.py
+++ b/src/maestro/strategies/base.py
@@ -3,6 +3,7 @@ MAESTRO — Abstract strategy interface
 All orchestration strategies (single agent, SOP, CrewAI, LangGraph) implement this.
 """
 
+import time
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -47,3 +48,39 @@ class BaseStrategy(ABC):
         ``RunConfig.strategy`` instead.
         """
         return self.__class__.__name__
+
+    def _error_result(
+        self,
+        config: RunConfig,
+        message: str,
+        *,
+        start: Optional[float] = None,
+    ) -> tuple[RunResult, list[SubResult]]:
+        """
+        Build a failed ``(RunResult, [])`` for errors that prevent normal
+        execution — file not found, JSON parse failure, control-strategy
+        I/O failure, etc.
+
+        Token counts and ``cost_usd`` are zero. ``duration_ms`` is the
+        wall-clock since ``start`` (use ``time.monotonic()`` at the
+        strategy entry point) when supplied, else ``0`` for errors that
+        happen before any work was attempted.
+
+        Two callers exist today:
+        - SOP / CrewAI / LangGraph / SingleAgent abort *before* any
+          monotonic-clock start, so they omit ``start`` and get
+          ``duration_ms=0``. The error is structural, not measured work.
+        - Control strategies pass ``start=`` so the (small but real)
+          wall-clock cost of the failed file read is still recorded.
+        """
+        duration_ms = int((time.monotonic() - start) * 1000) if start is not None else 0
+        result = RunResult(
+            run_id=config.run_id,
+            output_diagram_code=None,
+            prompt_tokens=0,
+            completion_tokens=0,
+            duration_ms=duration_ms,
+            cost_usd=0.0,
+            error=message,
+        )
+        return (result, [])

--- a/src/maestro/strategies/controls.py
+++ b/src/maestro/strategies/controls.py
@@ -1,8 +1,17 @@
 """
 MAESTRO — Control strategies.
 
-Three deterministic strategies that bypass the LLM entirely. They serve two
-distinct purposes in the experimental design:
+**Controls are not baselines.** ``SingleAgentStrategy`` (in ``single.py``)
+is the *comparison baseline* — the simplest real LLM-using approach that
+the orchestration strategies are measured against. The classes here are
+*control conditions* in the DSR / experimental-method sense: deterministic
+non-strategies that bypass the LLM entirely and have a known expected
+score, used to isolate the metric pipeline from the model under test.
+
+The two words got conflated in early issue language; keep them distinct
+in code, prose and (eventually) thesis text.
+
+These three deterministic strategies serve two distinct purposes:
 
 1. **Metric-pipeline sanity checks.** A normalization bug that makes the
    empty string match anything would make every real strategy look better
@@ -15,10 +24,7 @@ distinct purposes in the experimental design:
    control F1 = 0.00, ground-truth control F1 = 1.00" frames the result
    on a known scale.
 
-Naming follows the DSR convention: these are *control conditions*, not
-"baselines" (the issue used baseline loosely — ``SingleAgentStrategy``
-already calls itself the baseline in the comparison sense). All class
-names keep the ``Strategy`` suffix per ``coderabbit.yaml``.
+All class names keep the ``Strategy`` suffix per ``coderabbit.yaml``.
 
 Determinism: each control's output is a pure function of the input file
 (NullControl ignores even that). The matrix builder collapses the
@@ -102,9 +108,8 @@ class CopyInputControlStrategy(BaseStrategy):
         try:
             raw = input_file.file_path.read_text(encoding="utf-8")
         except Exception as e:
-            return (
-                self._file_error(config, start, f"Failed to read input file: {e}"),
-                [],
+            return self._error_result(
+                config, f"Failed to read input file: {e}", start=start
             )
 
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -117,17 +122,6 @@ class CopyInputControlStrategy(BaseStrategy):
             cost_usd=0.0,
         )
         return (result, [])
-
-    def _file_error(self, config: RunConfig, start: float, message: str) -> RunResult:
-        return RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=int((time.monotonic() - start) * 1000),
-            cost_usd=0.0,
-            error=message,
-        )
 
 
 class GroundTruthEchoControlStrategy(BaseStrategy):
@@ -158,9 +152,8 @@ class GroundTruthEchoControlStrategy(BaseStrategy):
         try:
             truth = input_file.ground_truth_path.read_text(encoding="utf-8")
         except Exception as e:
-            return (
-                self._file_error(config, start, f"Failed to read ground truth: {e}"),
-                [],
+            return self._error_result(
+                config, f"Failed to read ground truth: {e}", start=start
             )
 
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -173,14 +166,3 @@ class GroundTruthEchoControlStrategy(BaseStrategy):
             cost_usd=0.0,
         )
         return (result, [])
-
-    def _file_error(self, config: RunConfig, start: float, message: str) -> RunResult:
-        return RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=int((time.monotonic() - start) * 1000),
-            cost_usd=0.0,
-            error=message,
-        )

--- a/src/maestro/strategies/crew.py
+++ b/src/maestro/strategies/crew.py
@@ -245,11 +245,13 @@ class CrewAIStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:  # noqa: BLE001
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         sub_results: list[SubResult] = []
         step_outputs: dict[str, str] = {}
@@ -472,18 +474,3 @@ class CrewAIStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """File-level error before any LLM call — same shape as SOP."""
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])

--- a/src/maestro/strategies/langgraph.py
+++ b/src/maestro/strategies/langgraph.py
@@ -287,11 +287,13 @@ class LangGraphStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         total_start = time.monotonic()
 
@@ -363,18 +365,3 @@ class LangGraphStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """File-level error before any LLM call — same shape as SOP and CrewAI."""
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])

--- a/src/maestro/strategies/single.py
+++ b/src/maestro/strategies/single.py
@@ -1,7 +1,20 @@
 """
-MAESTRO — Single Agent strategy (baseline)
-One prompt, one LLM call, one diagram output.
-This is the control condition all other strategies are compared against.
+MAESTRO — Single Agent strategy (comparison baseline)
+
+One prompt, one LLM call, one diagram output. This is the *comparison
+baseline*: the simplest LLM-using approach that CrewAI / SOP / LangGraph
+are measured against. It is NOT a control — controls (NullControl,
+CopyInputControl, GroundTruthEchoControl in ``controls.py``) bypass the
+LLM entirely and serve a different role (metric-pipeline sanity checks).
+
+Vocabulary cheat sheet for this codebase:
+- "Baseline" = the simplest *real* strategy in the comparison set
+  (i.e. this file). Answers "does orchestration X beat no orchestration?".
+- "Control"  = a non-strategy with a known expected score. Answers
+  "is the metric pipeline correctly scoring things?".
+
+These two roles got conflated in earlier iterations of the codebase
+(and in the original issue language). They are distinct.
 """
 
 import json
@@ -27,10 +40,12 @@ Input data:
 
 class SingleAgentStrategy(BaseStrategy):
     """
-    Baseline strategy: one prompt → one LLM call → diagram code.
+    Comparison baseline: one prompt → one LLM call → diagram code.
 
-    No decomposition, no multi-step reasoning, no tool use.
-    Establishes the lower bound for comparison with orchestrated strategies.
+    No decomposition, no multi-step reasoning, no tool use. Establishes
+    the *no-orchestration* reference point that CrewAI, SOP and LangGraph
+    are compared against. Distinct from the control strategies in
+    ``controls.py``, which bypass the LLM entirely.
     """
 
     def run(
@@ -46,34 +61,17 @@ class SingleAgentStrategy(BaseStrategy):
             input_data = json.loads(raw)
 
         except FileNotFoundError:
-            return self._file_error(
+            return self._error_result(
                 config, f"Input file not found: {input_file.file_path}"
             )
         except json.JSONDecodeError as e:
-            return self._file_error(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._file_error(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         formatted_input = json.dumps(input_data, indent=2)
         prompt = PROMPT_TEMPLATE.format(input_data=formatted_input)
 
         # Single call — wrap result in tuple with empty sub_results
         result = self.provider.complete(prompt, config)
-        return (result, [])
-
-    def _file_error(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """
-        Return a failed RunResult for file-level errors before any LLM call.
-        """
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
         return (result, [])

--- a/src/maestro/strategies/sop.py
+++ b/src/maestro/strategies/sop.py
@@ -96,11 +96,13 @@ class SOPStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         sub_results: list[SubResult] = []
         # Intermediate outputs passed between steps
@@ -270,20 +272,3 @@ class SOPStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """
-        Return a failed run for file-level errors before any LLM call.
-        """
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])


### PR DESCRIPTION
Replaces five near-identical helpers with a single `_error_result` on BaseStrategy:

Before                                                 | After
------------------------------------+--------------------
SingleAgent._file_error                      | BaseStrategy._error_result
SOPStrategy._abort                           | BaseStrategy._error_result
CrewAIStrategy._abort                       | BaseStrategy._error_result
LangGraphStrategy._abort                | BaseStrategy._error_result
CopyInputControl._file_error             | BaseStrategy._error_result
GroundTruthEchoControl._file_error | BaseStrategy._error_result

The helper covers both shapes the old methods needed:

- LLM strategies abort before any work — they omit `start` and get `duration_ms=0`, matching the previous `_abort` semantics exactly.
- Control strategies pass `start=time.monotonic()` so the (small but real) wall-clock cost of a failed file read is still recorded - preserves the previous controls semantics.

Also drops the tuple-wrapping at the two control call sites that used to do `(self._file_error(...), [])` — the new helper returns the tuple directly.

`SOPStrategy._aggregate` is intentionally NOT migrated: different shape (sums sub-result tokens/cost, returns the actual subs not []). Out of scope for this consolidation.

Vocabulary cleanup (bundled — same domain): the codebase had two contradictory uses of "baseline" / "control".
SingleAgentStrategy's module docstring described itself as a "control condition" while its class docstring (correctly) called itself a baseline. Tightened all three relevant docstrings to make the distinction explicit:

- "Baseline" (= SingleAgentStrategy): the simplest *real* LLM strategy. Answers "does orchestration X beat no orchestration?".
- "Control"  (= NullControl, CopyControl, GroundTruthEchoControl): a non-strategy with a known expected score. Answers "is the metric pipeline correctly scoring things?".

Net 24 lines removed; behaviour preserved across all five strategies verified by:
- pytest 9/9 still passing (including SOP system_prompt regression)
- ruff check + format check both clean
- End-to-end error-path smoketest on all 5 strategies pointed at non-existent files: each returns the expected `(RunResult(error=..., duration_ms=0), [])` shape
- `python -m maestro.run --dry-run` unchanged (83-row matrix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across strategy implementations through a centralized error result mechanism, ensuring consistent error messages and timeout tracking when operations fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->