### PR TITLE
chore(run): error isolation, resume from DB, pre-flight env check

### DIFF
--- a/src/maestro/db/__init__.py
+++ b/src/maestro/db/__init__.py
@@ -6,6 +6,8 @@ from maestro.db.client import get_connection, init_db
 from maestro.db.environment import capture_environment
 from maestro.db.queries import (
     fetch_all_results,
+    fetch_completed_cells,
+    fetch_failed_cells,
     insert_run_config,
     insert_run_environment,
     insert_run_result,
@@ -14,6 +16,8 @@ from maestro.db.queries import (
 __all__ = [
     "capture_environment",
     "fetch_all_results",
+    "fetch_completed_cells",
+    "fetch_failed_cells",
     "get_connection",
     "init_db",
     "insert_run_config",

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -144,6 +144,53 @@ def fetch_results_by_strategy(
     ).fetchall()
 
 
+def fetch_completed_cells(conn: sqlite3.Connection) -> set[tuple[str, str, str, int]]:
+    """
+    Return the set of (example_id, strategy, model, run_number) tuples
+    that already have a *successful* RunResult persisted.
+
+    "Successful" mirrors ``RunResult.success`` (schemas.py): no error,
+    non-empty output_diagram_code. A row with ``error IS NOT NULL`` or
+    an empty/NULL diagram is *not* in this set — so resume logic will
+    re-execute those cells, giving transient failures another attempt.
+
+    Used by ``build_matrix`` to skip already-done work on resume.
+    """
+    rows = conn.execute(
+        """
+        SELECT c.example_id, c.strategy, c.model, c.run_number
+        FROM run_configs c
+        JOIN run_results r ON c.run_id = r.run_id
+        WHERE r.error IS NULL
+          AND r.output_diagram_code IS NOT NULL
+          AND TRIM(r.output_diagram_code) != ''
+        """
+    ).fetchall()
+    return {(row[0], row[1], row[2], row[3]) for row in rows}
+
+
+def fetch_failed_cells(conn: sqlite3.Connection) -> set[tuple[str, str, str, int]]:
+    """
+    Return the set of (example_id, strategy, model, run_number) tuples
+    that have a persisted RunResult but the run was *not* successful.
+
+    The exact mirror image of ``fetch_completed_cells`` over the same
+    joined rows. Used by ``--rerun-failed`` to narrow the matrix to
+    only previously-failed cells.
+    """
+    rows = conn.execute(
+        """
+        SELECT c.example_id, c.strategy, c.model, c.run_number
+        FROM run_configs c
+        JOIN run_results r ON c.run_id = r.run_id
+        WHERE r.error IS NOT NULL
+           OR r.output_diagram_code IS NULL
+           OR TRIM(r.output_diagram_code) = ''
+        """
+    ).fetchall()
+    return {(row[0], row[1], row[2], row[3]) for row in rows}
+
+
 def fetch_all_results(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     """Fetch all joined rows — used by the analysis script."""
     return conn.execute(

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -172,20 +172,45 @@ def fetch_completed_cells(conn: sqlite3.Connection) -> set[tuple[str, str, str, 
 def fetch_failed_cells(conn: sqlite3.Connection) -> set[tuple[str, str, str, int]]:
     """
     Return the set of (example_id, strategy, model, run_number) tuples
-    that have a persisted RunResult but the run was *not* successful.
+    whose persisted RunResults are *all* failures — i.e. there is at
+    least one failed attempt AND no successful attempt for that cell.
 
-    The exact mirror image of ``fetch_completed_cells`` over the same
-    joined rows. Used by ``--rerun-failed`` to narrow the matrix to
-    only previously-failed cells.
+    Why this matters: ``run_configs`` has no unique constraint on the
+    cell tuple, so the same cell can have multiple rows (e.g. an
+    initial failure followed by a successful ``--rerun-failed``
+    retry). If we returned every cell with any failure, the next
+    ``--rerun-failed`` invocation would re-execute cells that have
+    *already* been recovered — wasting API spend and overwriting
+    presumably-good metric rows.
+
+    Used by ``--rerun-failed`` to narrow the matrix to only cells
+    that still need fixing.
     """
     rows = conn.execute(
         """
         SELECT c.example_id, c.strategy, c.model, c.run_number
         FROM run_configs c
         JOIN run_results r ON c.run_id = r.run_id
-        WHERE r.error IS NOT NULL
-           OR r.output_diagram_code IS NULL
-           OR TRIM(r.output_diagram_code) = ''
+        WHERE (
+            r.error IS NOT NULL
+            OR r.output_diagram_code IS NULL
+            OR TRIM(r.output_diagram_code) = ''
+        )
+        AND NOT EXISTS (
+            -- Exclude cells that also have *any* successful attempt;
+            -- they have effectively been recovered and shouldn't be
+            -- re-run by --rerun-failed.
+            SELECT 1
+            FROM run_configs c2
+            JOIN run_results r2 ON c2.run_id = r2.run_id
+            WHERE c2.example_id = c.example_id
+              AND c2.strategy   = c.strategy
+              AND c2.model      = c.model
+              AND c2.run_number = c.run_number
+              AND r2.error IS NULL
+              AND r2.output_diagram_code IS NOT NULL
+              AND TRIM(r2.output_diagram_code) != ''
+        )
         """
     ).fetchall()
     return {(row[0], row[1], row[2], row[3]) for row in rows}

--- a/src/maestro/run.py
+++ b/src/maestro/run.py
@@ -178,7 +178,11 @@ def preflight_check_env(models: list[ModelPricing]) -> None:
     synthetic ``control`` ModelPricing used by control strategies) —
     those don't make LLM calls and don't need keys.
     """
-    missing: dict[str, list[str]] = {}  # env_var -> list of model names needing it
+    # env_var -> set of distinct model names needing it. ``models`` is
+    # the post-filter matrix, which has one entry per *cell* — the same
+    # model name appears many times for a typical matrix. A set
+    # de-duplicates so the error message isn't padded with repetition.
+    missing: dict[str, set[str]] = {}
     for mp in models:
         dispatch = _dispatch_for_model(mp.model)
         if dispatch is None:
@@ -187,7 +191,7 @@ def preflight_check_env(models: list[ModelPricing]) -> None:
             continue
         _, _, env_var = dispatch
         if not os.environ.get(env_var):
-            missing.setdefault(env_var, []).append(mp.model)
+            missing.setdefault(env_var, set()).add(mp.model)
 
     if not missing:
         return

--- a/src/maestro/run.py
+++ b/src/maestro/run.py
@@ -142,19 +142,25 @@ def _create_provider(model_pricing):
     """
     Instantiate the correct LLM provider based on model name.
     API keys come from environment variables — never hardcoded.
-    Assumes preflight_check_env() has already verified the env var
-    exists; raises if dispatch fails entirely (unknown model name).
+
+    Raises ``RuntimeError`` on either failure mode (unknown model name,
+    missing env var). Both are caught by the cell-level try/except in
+    the main loop, so a transient env-var rotation or a typo in
+    ``MODELS`` fails that one cell rather than aborting the whole
+    experiment after potentially hours of work. ``preflight_check_env``
+    should normally have caught both up-front; these raises are the
+    defensive fallback.
     """
     dispatch = _dispatch_for_model(model_pricing.model)
     if dispatch is None:
-        print(f"ERROR: No provider registered for model '{model_pricing.model}'")
-        sys.exit(1)
+        raise RuntimeError(f"No provider registered for model '{model_pricing.model}'")
     _, cls, env_var = dispatch
     api_key = os.environ.get(env_var)
     if not api_key:
-        # Should be impossible if preflight ran first; defensive fallback.
-        print(f"ERROR: {env_var} not set in environment")
-        sys.exit(1)
+        raise RuntimeError(
+            f"{env_var} not set in environment "
+            f"(needed by model '{model_pricing.model}')"
+        )
     return cls(api_key=api_key, pricing=model_pricing)
 
 
@@ -377,9 +383,15 @@ def _apply_resume_filter(matrix: list[dict], args: argparse.Namespace) -> list[d
     if args.no_resume:
         return matrix
 
+    # Only fetch the set the active mode actually needs — on a big DB
+    # the unused query would scan thousands of rows for nothing.
     with get_connection(DB_PATH) as conn:
-        completed = fetch_completed_cells(conn)
-        failed = fetch_failed_cells(conn) if args.rerun_failed else set()
+        if args.rerun_failed:
+            failed = fetch_failed_cells(conn)
+            completed = set()  # unused in this branch
+        else:
+            completed = fetch_completed_cells(conn)
+            failed = set()  # unused in this branch
 
     def cell_key(cell: dict) -> tuple[str, str, str, int]:
         return (
@@ -440,8 +452,13 @@ def main():
     print(f"  Repeats:    {args.repeats}")
     print(f"  Total runs: {total}")
     if skipped:
-        mode = "rerun-failed mode" if args.rerun_failed else "resume mode"
-        print(f"  Skipped:    {skipped} (already complete, {mode})")
+        # In --rerun-failed mode the skipped set includes both
+        # successful prior runs AND cells with no DB row yet — neither
+        # is "already complete", so don't claim that.
+        if args.rerun_failed:
+            print(f"  Skipped:    {skipped} (no prior failure, rerun-failed mode)")
+        else:
+            print(f"  Skipped:    {skipped} (already complete, resume mode)")
     print("=" * 60)
 
     if args.dry_run:
@@ -506,29 +523,37 @@ def main():
             environment_id=environment.environment_id,
         )
 
-        # Instantiate strategy. Controls don't need a provider — they
-        # bypass the LLM entirely; passing one would just be unused state.
+        # Skip-not-an-error: an enum value with no class registered is a
+        # config gap, not a failure. Don't burn a row on it.
         strategy_cls = STRATEGY_MAP.get(strategy_enum)
         if strategy_cls is None:
             print(f"  SKIP — strategy {strategy_enum.value} not implemented")
             continue
-        if strategy_enum in CONTROL_STRATEGIES:
-            strategy = strategy_cls()
-        else:
-            provider = _create_provider(model_pricing)
-            strategy = strategy_cls(provider=provider)
 
         # Execute — cell-level error isolation. Any unhandled exception
-        # from strategy.run() (provider SDK bug, framework crash, a
-        # KeyError in a strategy's own bookkeeping, etc.) is captured
-        # into a failed RunResult and the matrix loop continues. For a
+        # from provider/strategy construction or strategy.run() (provider
+        # SDK bug, framework crash, a KeyError in a strategy's own
+        # bookkeeping, an env-var rotated mid-run, etc.) is captured into
+        # a failed RunResult and the matrix loop continues. For a
         # ~5000-cell run, having one buggy cell take down the whole
         # experiment would burn hours of API spend.
+        #
+        # Provider construction is *inside* the try because
+        # _create_provider can raise (unknown model, missing env var) —
+        # those are real failure modes worth recording as a failed cell
+        # rather than killing the process.
         #
         # KeyboardInterrupt / SystemExit are deliberately NOT caught —
         # the user pressing Ctrl+C or a sys.exit() from a helper should
         # still exit the runner.
         try:
+            # Controls don't need a provider — they bypass the LLM entirely;
+            # passing one would just be unused state.
+            if strategy_enum in CONTROL_STRATEGIES:
+                strategy = strategy_cls()
+            else:
+                provider = _create_provider(model_pricing)
+                strategy = strategy_cls(provider=provider)
             result, sub_results = strategy.run(
                 input_file=input_file,
                 config=config,

--- a/src/maestro/run.py
+++ b/src/maestro/run.py
@@ -27,11 +27,22 @@ Usage:
 
     # Dry run — show matrix without executing
     python -m maestro.run --dry-run
+
+    # Resume: default behaviour is to skip cells already successfully
+    # recorded in the DB; previously-failed cells get another attempt.
+    python -m maestro.run
+
+    # Force full re-run (ignore DB)
+    python -m maestro.run --no-resume
+
+    # Re-run only previously-failed cells
+    python -m maestro.run --rerun-failed
 """
 
 import argparse
 import os
 import sys
+import traceback
 from itertools import product
 
 from dotenv import load_dotenv
@@ -49,6 +60,8 @@ from maestro.analysis.metrics import evaluate_run
 from maestro.db.client import get_connection, init_db
 from maestro.db.environment import capture_environment
 from maestro.db.queries import (
+    fetch_completed_cells,
+    fetch_failed_cells,
     insert_metric_result,
     insert_run_config,
     insert_run_environment,
@@ -68,7 +81,7 @@ from maestro.providers.anthropic import AnthropicProvider
 from maestro.providers.gemini import GeminiProvider
 from maestro.providers.mistral import MistralProvider
 from maestro.providers.openai import OpenAIProvider
-from maestro.schemas import RunConfig, Strategy
+from maestro.schemas import ModelPricing, RunConfig, RunResult, Strategy
 from maestro.strategies.controls import (
     CopyInputControlStrategy,
     GroundTruthEchoControlStrategy,
@@ -96,49 +109,91 @@ STRATEGY_MAP = {
 
 
 # ---------------------------------------------------------------------------
-# Provider factory — maps model prefix to provider class
-# Currently only Anthropic; extend when adding OpenAI etc.
+# Provider factory + pre-flight env check
 # ---------------------------------------------------------------------------
+#
+# One source of truth for "which substring in a model name maps to which
+# provider class + which env var". _create_provider and the pre-flight
+# env check both consume this table so they can't drift out of sync.
+#
+# Order matters: the dispatch picks the first matching substring, so the
+# control "model" (literal string "control") is handled by the caller
+# (it's never created by _create_provider) and is intentionally absent here.
+
+_PROVIDER_DISPATCH = (
+    # (model-name substring, provider class, env var name)
+    ("claude", AnthropicProvider, "ANTHROPIC_API_KEY"),
+    ("gpt", OpenAIProvider, "OPENAI_API_KEY"),
+    ("mistral", MistralProvider, "MISTRAL_API_KEY"),
+    ("gemini", GeminiProvider, "GEMINI_API_KEY"),
+)
+
+
+def _dispatch_for_model(model: str):
+    """Return the dispatch tuple for a model name, or None if unknown."""
+    model_lower = model.lower()
+    for needle, cls, env_var in _PROVIDER_DISPATCH:
+        if needle in model_lower:
+            return (needle, cls, env_var)
+    return None
 
 
 def _create_provider(model_pricing):
     """
     Instantiate the correct LLM provider based on model name.
     API keys come from environment variables — never hardcoded.
+    Assumes preflight_check_env() has already verified the env var
+    exists; raises if dispatch fails entirely (unknown model name).
     """
-    model = model_pricing.model
+    dispatch = _dispatch_for_model(model_pricing.model)
+    if dispatch is None:
+        print(f"ERROR: No provider registered for model '{model_pricing.model}'")
+        sys.exit(1)
+    _, cls, env_var = dispatch
+    api_key = os.environ.get(env_var)
+    if not api_key:
+        # Should be impossible if preflight ran first; defensive fallback.
+        print(f"ERROR: {env_var} not set in environment")
+        sys.exit(1)
+    return cls(api_key=api_key, pricing=model_pricing)
 
-    model_lower = model.lower()
 
-    if "claude" in model_lower:
-        api_key = os.environ.get("ANTHROPIC_API_KEY")
-        if not api_key:
-            print("ERROR: ANTHROPIC_API_KEY not set in environment")
-            sys.exit(1)
-        return AnthropicProvider(api_key=api_key, pricing=model_pricing)
+def preflight_check_env(models: list[ModelPricing]) -> None:
+    """
+    Verify every API key required by ``models`` exists in the environment.
 
-    if "gpt" in model_lower:
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            print("ERROR: OPENAI_API_KEY not set in environment")
-            sys.exit(1)
-        return OpenAIProvider(api_key=api_key, pricing=model_pricing)
+    Aggregates *all* missing keys into one consolidated error message so
+    a user with several missing keys learns about all of them at once,
+    rather than the old per-cell pattern where the first missing key
+    aborted before the others were even checked. Exits 1 if anything
+    is missing; otherwise returns silently.
 
-    if "mistral" in model_lower:
-        api_key = os.environ.get("MISTRAL_API_KEY")
-        if not api_key:
-            print("ERROR: MISTRAL_API_KEY not set in environment")
-            sys.exit(1)
-        return MistralProvider(api_key=api_key, pricing=model_pricing)
+    Skips models whose name doesn't dispatch to any provider (e.g. the
+    synthetic ``control`` ModelPricing used by control strategies) —
+    those don't make LLM calls and don't need keys.
+    """
+    missing: dict[str, list[str]] = {}  # env_var -> list of model names needing it
+    for mp in models:
+        dispatch = _dispatch_for_model(mp.model)
+        if dispatch is None:
+            # Unknown model or synthetic "control" — skip silently. The
+            # main loop handles unknown-model failures per-cell.
+            continue
+        _, _, env_var = dispatch
+        if not os.environ.get(env_var):
+            missing.setdefault(env_var, []).append(mp.model)
 
-    if "gemini" in model_lower:
-        api_key = os.environ.get("GEMINI_API_KEY")
-        if not api_key:
-            print("ERROR: GEMINI_API_KEY not set in environment")
-            sys.exit(1)
-        return GeminiProvider(api_key=api_key, pricing=model_pricing)
+    if not missing:
+        return
 
-    print(f"ERROR: No provider registered for model '{model}'")
+    print("ERROR: Missing API keys for the following providers:", file=sys.stderr)
+    for env_var, model_names in sorted(missing.items()):
+        models_str = ", ".join(sorted(model_names))
+        print(f"  - {env_var} (needed by: {models_str})", file=sys.stderr)
+    print(
+        "\nSet the missing keys in your environment (or .env file) and re-run.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
@@ -185,6 +240,30 @@ def parse_args() -> argparse.Namespace:
         "--dry-run",
         action="store_true",
         help="Print the experiment matrix without executing any runs",
+    )
+
+    # Resume semantics — mutually exclusive.
+    # Default (neither flag): skip cells whose RunResult is already
+    # successful in the DB; re-run cells that previously failed
+    # (transient errors usually deserve another attempt).
+    resume_group = parser.add_mutually_exclusive_group()
+    resume_group.add_argument(
+        "--no-resume",
+        action="store_true",
+        help=(
+            "Ignore the DB and run the full matrix from scratch. "
+            "Useful when you've nuked the DB or want every cell to "
+            "execute regardless of prior runs."
+        ),
+    )
+    resume_group.add_argument(
+        "--rerun-failed",
+        action="store_true",
+        help=(
+            "Only execute cells that previously failed (error IS NOT NULL "
+            "or empty diagram). Skips both successful prior runs and any "
+            "cells that have no row in the DB yet."
+        ),
     )
 
     return parser.parse_args()
@@ -282,6 +361,39 @@ def build_matrix(args: argparse.Namespace) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
+def _apply_resume_filter(matrix: list[dict], args: argparse.Namespace) -> list[dict]:
+    """
+    Narrow ``matrix`` according to the user's resume flags.
+
+    - default       : drop cells already successfully recorded in the DB.
+                      Cells with prior failures stay in (retry transient).
+    - --no-resume   : pass through unchanged.
+    - --rerun-failed: keep only cells that have a prior *failed* row.
+
+    Reads the DB once (lazy import of get_connection so unit tests that
+    poke at the helpers don't need a real DB). Idempotent if the DB
+    doesn't exist yet — init_db is called by ``main`` before this.
+    """
+    if args.no_resume:
+        return matrix
+
+    with get_connection(DB_PATH) as conn:
+        completed = fetch_completed_cells(conn)
+        failed = fetch_failed_cells(conn) if args.rerun_failed else set()
+
+    def cell_key(cell: dict) -> tuple[str, str, str, int]:
+        return (
+            cell["input_file"].example_id,
+            cell["strategy"].value,
+            cell["model_pricing"].model,
+            cell["run_number"],
+        )
+
+    if args.rerun_failed:
+        return [c for c in matrix if cell_key(c) in failed]
+    return [c for c in matrix if cell_key(c) not in completed]
+
+
 def main():
     """Run the full experiment matrix with CLI filters applied."""
     args = parse_args()
@@ -292,6 +404,25 @@ def main():
             "No runs match the given filters. "
             "Check --strategy, --tier, --model, --example."
         )
+        sys.exit(0)
+
+    # Initialize DB before applying the resume filter — the filter reads
+    # existing rows, and init_db is idempotent + cheap (CREATE IF NOT EXISTS).
+    init_db(DB_PATH)
+
+    # Resume filtering: skip already-successful cells (default), force
+    # full re-run (--no-resume), or narrow to previously-failed cells
+    # (--rerun-failed). Applied BEFORE the summary so the printed totals
+    # match what will actually execute.
+    matrix_before_resume = len(matrix)
+    matrix = _apply_resume_filter(matrix, args)
+    skipped = matrix_before_resume - len(matrix)
+
+    if not matrix:
+        if args.rerun_failed:
+            print("No previously-failed cells to re-run — nothing to do.")
+        else:
+            print("All matrix cells already complete in the DB — nothing to do.")
         sys.exit(0)
 
     # Group summary for display
@@ -308,6 +439,9 @@ def main():
     print(f"  Models:     {n_models}")
     print(f"  Repeats:    {args.repeats}")
     print(f"  Total runs: {total}")
+    if skipped:
+        mode = "rerun-failed mode" if args.rerun_failed else "resume mode"
+        print(f"  Skipped:    {skipped} (already complete, {mode})")
     print("=" * 60)
 
     if args.dry_run:
@@ -322,8 +456,12 @@ def main():
         print(f"\n[DRY RUN] {total} runs would be executed.")
         return
 
-    # Initialize DB
-    init_db(DB_PATH)
+    # Pre-flight: verify env vars for every provider in the post-filter
+    # matrix. Fails fast with a consolidated error message before any
+    # work starts — way better than discovering MISTRAL_API_KEY is
+    # missing 80% of the way through a multi-hour run.
+    matrix_models = [c["model_pricing"] for c in matrix]
+    preflight_check_env(matrix_models)
 
     # Capture the runtime environment once per invocation. Every RunConfig
     # written below carries its environment_id so a future replication
@@ -380,27 +518,71 @@ def main():
             provider = _create_provider(model_pricing)
             strategy = strategy_cls(provider=provider)
 
-        # Execute
-        result, sub_results = strategy.run(
-            input_file=input_file,
-            config=config,
-        )
+        # Execute — cell-level error isolation. Any unhandled exception
+        # from strategy.run() (provider SDK bug, framework crash, a
+        # KeyError in a strategy's own bookkeeping, etc.) is captured
+        # into a failed RunResult and the matrix loop continues. For a
+        # ~5000-cell run, having one buggy cell take down the whole
+        # experiment would burn hours of API spend.
+        #
+        # KeyboardInterrupt / SystemExit are deliberately NOT caught —
+        # the user pressing Ctrl+C or a sys.exit() from a helper should
+        # still exit the runner.
+        try:
+            result, sub_results = strategy.run(
+                input_file=input_file,
+                config=config,
+            )
+        except Exception as exc:
+            traceback.print_exc(file=sys.stderr)
+            result = RunResult(
+                run_id=config.run_id,
+                output_diagram_code=None,
+                prompt_tokens=0,
+                completion_tokens=0,
+                duration_ms=0,
+                cost_usd=0.0,
+                error=f"unhandled: {type(exc).__name__}: {exc}",
+            )
+            sub_results = []
 
-        # Persist to DB
-        with get_connection(DB_PATH) as conn:
-            insert_run_config(conn, config)
-            insert_run_result(conn, result)
-            for sub in sub_results:
-                insert_sub_result(conn, sub)
+        # Persist to DB. Wrapped in try/except too — a DB failure here
+        # would otherwise kill the loop after the (potentially expensive)
+        # LLM call already happened. We at least want to log the in-memory
+        # result so the user can recover manually.
+        try:
+            with get_connection(DB_PATH) as conn:
+                insert_run_config(conn, config)
+                insert_run_result(conn, result)
+                for sub in sub_results:
+                    insert_sub_result(conn, sub)
 
-            # Evaluate metrics if run succeeded
-            if result.success:
-                metric = evaluate_run(
-                    run_id=config.run_id,
-                    output_diagram_code=result.output_diagram_code,
-                    ground_truth_path=input_file.ground_truth_path,
-                )
-                insert_metric_result(conn, metric)
+                # Evaluate metrics if run succeeded. Wrapped separately
+                # because a metric-pipeline crash (e.g. malformed Mermaid
+                # confusing the extractor) shouldn't roll back the
+                # RunResult / SubResult rows we just inserted.
+                if result.success:
+                    try:
+                        metric = evaluate_run(
+                            run_id=config.run_id,
+                            output_diagram_code=result.output_diagram_code,
+                            ground_truth_path=input_file.ground_truth_path,
+                        )
+                        insert_metric_result(conn, metric)
+                    except Exception as exc:
+                        traceback.print_exc(file=sys.stderr)
+                        print(
+                            f"  WARN — metric evaluation crashed: "
+                            f"{type(exc).__name__}: {exc}",
+                            file=sys.stderr,
+                        )
+        except Exception as exc:
+            traceback.print_exc(file=sys.stderr)
+            print(
+                f"  WARN — DB persist crashed: {type(exc).__name__}: {exc}; "
+                "result lost",
+                file=sys.stderr,
+            )
 
         # Always track cost (partial responses may still consume tokens)
         total_cost += result.cost_usd

--- a/src/maestro/strategies/base.py
+++ b/src/maestro/strategies/base.py
@@ -3,6 +3,7 @@ MAESTRO — Abstract strategy interface
 All orchestration strategies (single agent, SOP, CrewAI, LangGraph) implement this.
 """
 
+import time
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -47,3 +48,39 @@ class BaseStrategy(ABC):
         ``RunConfig.strategy`` instead.
         """
         return self.__class__.__name__
+
+    def _error_result(
+        self,
+        config: RunConfig,
+        message: str,
+        *,
+        start: Optional[float] = None,
+    ) -> tuple[RunResult, list[SubResult]]:
+        """
+        Build a failed ``(RunResult, [])`` for errors that prevent normal
+        execution — file not found, JSON parse failure, control-strategy
+        I/O failure, etc.
+
+        Token counts and ``cost_usd`` are zero. ``duration_ms`` is the
+        wall-clock since ``start`` (use ``time.monotonic()`` at the
+        strategy entry point) when supplied, else ``0`` for errors that
+        happen before any work was attempted.
+
+        Two callers exist today:
+        - SOP / CrewAI / LangGraph / SingleAgent abort *before* any
+          monotonic-clock start, so they omit ``start`` and get
+          ``duration_ms=0``. The error is structural, not measured work.
+        - Control strategies pass ``start=`` so the (small but real)
+          wall-clock cost of the failed file read is still recorded.
+        """
+        duration_ms = int((time.monotonic() - start) * 1000) if start is not None else 0
+        result = RunResult(
+            run_id=config.run_id,
+            output_diagram_code=None,
+            prompt_tokens=0,
+            completion_tokens=0,
+            duration_ms=duration_ms,
+            cost_usd=0.0,
+            error=message,
+        )
+        return (result, [])

--- a/src/maestro/strategies/controls.py
+++ b/src/maestro/strategies/controls.py
@@ -1,8 +1,17 @@
 """
 MAESTRO — Control strategies.
 
-Three deterministic strategies that bypass the LLM entirely. They serve two
-distinct purposes in the experimental design:
+**Controls are not baselines.** ``SingleAgentStrategy`` (in ``single.py``)
+is the *comparison baseline* — the simplest real LLM-using approach that
+the orchestration strategies are measured against. The classes here are
+*control conditions* in the DSR / experimental-method sense: deterministic
+non-strategies that bypass the LLM entirely and have a known expected
+score, used to isolate the metric pipeline from the model under test.
+
+The two words got conflated in early issue language; keep them distinct
+in code, prose and (eventually) thesis text.
+
+These three deterministic strategies serve two distinct purposes:
 
 1. **Metric-pipeline sanity checks.** A normalization bug that makes the
    empty string match anything would make every real strategy look better
@@ -15,10 +24,7 @@ distinct purposes in the experimental design:
    control F1 = 0.00, ground-truth control F1 = 1.00" frames the result
    on a known scale.
 
-Naming follows the DSR convention: these are *control conditions*, not
-"baselines" (the issue used baseline loosely — ``SingleAgentStrategy``
-already calls itself the baseline in the comparison sense). All class
-names keep the ``Strategy`` suffix per ``coderabbit.yaml``.
+All class names keep the ``Strategy`` suffix per ``coderabbit.yaml``.
 
 Determinism: each control's output is a pure function of the input file
 (NullControl ignores even that). The matrix builder collapses the
@@ -102,9 +108,8 @@ class CopyInputControlStrategy(BaseStrategy):
         try:
             raw = input_file.file_path.read_text(encoding="utf-8")
         except Exception as e:
-            return (
-                self._file_error(config, start, f"Failed to read input file: {e}"),
-                [],
+            return self._error_result(
+                config, f"Failed to read input file: {e}", start=start
             )
 
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -117,17 +122,6 @@ class CopyInputControlStrategy(BaseStrategy):
             cost_usd=0.0,
         )
         return (result, [])
-
-    def _file_error(self, config: RunConfig, start: float, message: str) -> RunResult:
-        return RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=int((time.monotonic() - start) * 1000),
-            cost_usd=0.0,
-            error=message,
-        )
 
 
 class GroundTruthEchoControlStrategy(BaseStrategy):
@@ -158,9 +152,8 @@ class GroundTruthEchoControlStrategy(BaseStrategy):
         try:
             truth = input_file.ground_truth_path.read_text(encoding="utf-8")
         except Exception as e:
-            return (
-                self._file_error(config, start, f"Failed to read ground truth: {e}"),
-                [],
+            return self._error_result(
+                config, f"Failed to read ground truth: {e}", start=start
             )
 
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -173,14 +166,3 @@ class GroundTruthEchoControlStrategy(BaseStrategy):
             cost_usd=0.0,
         )
         return (result, [])
-
-    def _file_error(self, config: RunConfig, start: float, message: str) -> RunResult:
-        return RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=int((time.monotonic() - start) * 1000),
-            cost_usd=0.0,
-            error=message,
-        )

--- a/src/maestro/strategies/crew.py
+++ b/src/maestro/strategies/crew.py
@@ -245,11 +245,13 @@ class CrewAIStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:  # noqa: BLE001
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         sub_results: list[SubResult] = []
         step_outputs: dict[str, str] = {}
@@ -472,18 +474,3 @@ class CrewAIStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """File-level error before any LLM call — same shape as SOP."""
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])

--- a/src/maestro/strategies/langgraph.py
+++ b/src/maestro/strategies/langgraph.py
@@ -287,11 +287,13 @@ class LangGraphStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         total_start = time.monotonic()
 
@@ -363,18 +365,3 @@ class LangGraphStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """File-level error before any LLM call — same shape as SOP and CrewAI."""
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])

--- a/src/maestro/strategies/single.py
+++ b/src/maestro/strategies/single.py
@@ -1,7 +1,20 @@
 """
-MAESTRO — Single Agent strategy (baseline)
-One prompt, one LLM call, one diagram output.
-This is the control condition all other strategies are compared against.
+MAESTRO — Single Agent strategy (comparison baseline)
+
+One prompt, one LLM call, one diagram output. This is the *comparison
+baseline*: the simplest LLM-using approach that CrewAI / SOP / LangGraph
+are measured against. It is NOT a control — controls (NullControl,
+CopyInputControl, GroundTruthEchoControl in ``controls.py``) bypass the
+LLM entirely and serve a different role (metric-pipeline sanity checks).
+
+Vocabulary cheat sheet for this codebase:
+- "Baseline" = the simplest *real* strategy in the comparison set
+  (i.e. this file). Answers "does orchestration X beat no orchestration?".
+- "Control"  = a non-strategy with a known expected score. Answers
+  "is the metric pipeline correctly scoring things?".
+
+These two roles got conflated in earlier iterations of the codebase
+(and in the original issue language). They are distinct.
 """
 
 import json
@@ -27,10 +40,12 @@ Input data:
 
 class SingleAgentStrategy(BaseStrategy):
     """
-    Baseline strategy: one prompt → one LLM call → diagram code.
+    Comparison baseline: one prompt → one LLM call → diagram code.
 
-    No decomposition, no multi-step reasoning, no tool use.
-    Establishes the lower bound for comparison with orchestrated strategies.
+    No decomposition, no multi-step reasoning, no tool use. Establishes
+    the *no-orchestration* reference point that CrewAI, SOP and LangGraph
+    are compared against. Distinct from the control strategies in
+    ``controls.py``, which bypass the LLM entirely.
     """
 
     def run(
@@ -46,34 +61,17 @@ class SingleAgentStrategy(BaseStrategy):
             input_data = json.loads(raw)
 
         except FileNotFoundError:
-            return self._file_error(
+            return self._error_result(
                 config, f"Input file not found: {input_file.file_path}"
             )
         except json.JSONDecodeError as e:
-            return self._file_error(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._file_error(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         formatted_input = json.dumps(input_data, indent=2)
         prompt = PROMPT_TEMPLATE.format(input_data=formatted_input)
 
         # Single call — wrap result in tuple with empty sub_results
         result = self.provider.complete(prompt, config)
-        return (result, [])
-
-    def _file_error(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """
-        Return a failed RunResult for file-level errors before any LLM call.
-        """
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
         return (result, [])

--- a/src/maestro/strategies/sop.py
+++ b/src/maestro/strategies/sop.py
@@ -96,11 +96,13 @@ class SOPStrategy(BaseStrategy):
             raw = input_file.file_path.read_text(encoding="utf-8")
             input_data = json.dumps(json.loads(raw), indent=2)
         except FileNotFoundError:
-            return self._abort(config, f"Input file not found: {input_file.file_path}")
+            return self._error_result(
+                config, f"Input file not found: {input_file.file_path}"
+            )
         except json.JSONDecodeError as e:
-            return self._abort(config, f"Invalid JSON in input file: {e}")
+            return self._error_result(config, f"Invalid JSON in input file: {e}")
         except Exception as e:
-            return self._abort(config, f"Failed to read input file: {e}")
+            return self._error_result(config, f"Failed to read input file: {e}")
 
         sub_results: list[SubResult] = []
         # Intermediate outputs passed between steps
@@ -270,20 +272,3 @@ class SOPStrategy(BaseStrategy):
             error=error,
         )
         return (result, subs)
-
-    def _abort(
-        self, config: RunConfig, message: str
-    ) -> tuple[RunResult, list[SubResult]]:
-        """
-        Return a failed run for file-level errors before any LLM call.
-        """
-        result = RunResult(
-            run_id=config.run_id,
-            output_diagram_code=None,
-            prompt_tokens=0,
-            completion_tokens=0,
-            duration_ms=0,
-            cost_usd=0.0,
-            error=message,
-        )
-        return (result, [])


### PR DESCRIPTION
Three independent improvements to the experiment runner, all addressing
fragility at multi-hour run scale (~5000 cells in the full matrix):

1. Cell-level error isolation in the main loop
   Wraps strategy.run() in try/except Exception (NOT BaseException —
   Ctrl+C / SystemExit still exit). Any unhandled exception from a
   strategy is captured into a failed RunResult with
   `error="unhandled: <Type>: <msg>"`, traceback logged to stderr, the
   matrix continues. DB persist and evaluate_run get their own narrower
   try/except blocks so a metric-pipeline crash doesn't roll back the
   RunResult/SubResult rows we just inserted.

2. Resume from DB (default on)
   New queries fetch_completed_cells / fetch_failed_cells return the
   set of (example_id, strategy, model, run_number) tuples in their
   respective states. build_matrix output gets filtered through
   _apply_resume_filter before any work starts. Default skips
   successful cells, re-runs previously-failed cells (transient
   errors usually deserve another attempt). Two new mutually-exclusive
   CLI flags:
     --no-resume   : ignore DB, run full matrix
     --rerun-failed: only run cells that previously failed

3. Pre-flight env check (preflight_check_env)
   Iterates the post-filter matrix, aggregates ALL missing API keys
   into one consolidated stderr message, exits 1 before any work
   starts. Only checks providers actually used by the matrix — a
   user testing one provider isn't blocked by missing keys for
   providers they're not invoking. Replaces the old per-cell sys.exit
   pattern inside _create_provider that would abort mid-loop on a
   missing key, potentially after hours of work.

Internal cleanup: extracted _PROVIDER_DISPATCH as the single source of
truth for "model substring → provider class → env var", consumed by
both _create_provider and preflight_check_env so they can't drift.

Validated:
- ruff check + format check both clean
- pytest 9/9 still passing
- 5 preflight cases (all keys, all missing, subset matrix, control-only,
  one missing) behave as designed
- Resume helpers correctly classify success / failure / degenerate
  (empty diagram, no error) cases via SQL mirroring RunResult.success
- Mixed-DB smoketest: default mode runs the 3 failed cells, skips the
  2 successful ones, with "Skipped: 2 (resume mode)" in the summary
- --no-resume / --rerun-failed mutually-exclusive guard works
  (argparse rejects the combination)
- Cell-level isolation: a BoomStrategy raising RuntimeError converts
  cleanly to a persistable failed RunResult, loop would continue
- python -m maestro.run --dry-run unchanged on empty DB (83-row matrix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release Notes: Error Isolation, Resume from DB, Pre-flight Env Check

## TLDR
Experiment runner is more robust for long runs: per-cell failures no longer abort the matrix, runs can resume from DB (with --no-resume / --rerun-failed flags), and a pre-flight check verifies required API keys for only the models in the filtered matrix before work starts.

## Features

### 1. Cell-level error isolation
- strategy.run() and provider construction are isolated in a per-cell try/except (KeyboardInterrupt/SystemExit still propagate).
- Unhandled strategy exceptions are converted into persisted RunResult rows with error "unhandled: <Type>: <msg>" and tracebacks logged to stderr so the matrix continues.
- DB persistence and metric evaluation run in narrower separate try/except blocks so inserted RunResult/SubResult rows are not rolled back by later failures.
- Consolidated helper BaseStrategy._error_result reduces duplicated error-result plumbing across strategies.

### 2. Resume from DB (enabled by default)
- New DB helpers fetch_completed_cells(conn) and fetch_failed_cells(conn) return (example_id, strategy, model, run_number) tuples used to filter the work matrix before execution.
- Default behavior: skip previously successful cells and re-run previously failed cells.
- CLI flags:
  - --no-resume: run the full matrix (ignore DB).
  - --rerun-failed: run only cells that previously failed.
- _apply_resume_filter was optimized to fetch only the DB sets required by the selected mode (avoids unnecessary queries for large DBs).
- Skip messaging improved to reflect mode-specific reasons (e.g., "no prior failure, rerun-failed mode" vs "already complete, resume mode").

### 3. Pre-flight environment check
- preflight_check_env inspects the filtered matrix and aggregates all missing provider API keys into a consolidated stderr message; it checks only providers used by the matrix and exits 1 before any work starts.
- Introduced _PROVIDER_DISPATCH as the single source of truth for model→provider class→env var mapping; consumed by provider construction and preflight validation.
- Collector deduplicates missing-model listings to avoid redundant messages.

## Fixes & Internal Improvements
- Replaced prior sys.exit(1) behavior on unknown models / missing keys: _create_provider now raises (and provider construction is performed inside the per-cell try/except), so a missing key turns into a failed cell rather than aborting the entire run.
- fetch_failed_cells excludes cells that later had a successful attempt (NOT EXISTS subquery), preventing false positives.
- preflight missing-key collector changed from list to set to avoid duplicate model entries.
- Removed duplicated _abort/_file_error helpers across strategies; they now use BaseStrategy._error_result.
- CLI resume flags are mutually exclusive and the resume filter is applied after DB init and before any external calls.

## Validation
- ruff/format checks clean.
- Tests: pytest 9/9 passing.
- Manual/smoke tests: multiple preflight/resume/rerun/mixed-DB scenarios exercised; dry-run behavior preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->