### PR TITLE
feat(analysis): timezone-aware timestamp display helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,14 @@ dependencies = [
     # >=8.1.0: that release introduced `wait_exponential_jitter`, which
     # _retry.py imports directly. 8.0.x lacks the symbol.
     "tenacity>=9.1.4",
+    # Windows-only: provides the IANA timezone database that zoneinfo
+    # (used by analysis/timestamps.py) needs at runtime. macOS and most
+    # Linux distros ship the DB with the OS, so this is a no-op there
+    # — the environment marker keeps the install footprint unchanged
+    # on the development OS. Without this, a Windows reviewer running
+    # the timestamp tests (or the analysis layer once #19/#24 ship)
+    # would hit ZoneInfoNotFoundError on every named zone.
+    "tzdata; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/src/maestro/analysis/__init__.py
+++ b/src/maestro/analysis/__init__.py
@@ -1,5 +1,9 @@
 """MAESTRO — analysis package (metrics + display helpers)."""
 
+# Two import blocks from the same module is intentional: ruff's isort
+# rules sort `as`-aliased imports separately from plain ones and will
+# split a merged block on every --fix. Leaving them split is the stable
+# shape that survives `ruff check --fix`.
 from maestro.analysis.timestamps import (
     ENV_VAR as DISPLAY_TZ_ENV_VAR,
 )

--- a/src/maestro/analysis/__init__.py
+++ b/src/maestro/analysis/__init__.py
@@ -1,0 +1,15 @@
+"""MAESTRO — analysis package (metrics + display helpers)."""
+
+from maestro.analysis.timestamps import (
+    ENV_VAR as DISPLAY_TZ_ENV_VAR,
+)
+from maestro.analysis.timestamps import (
+    format_for_display,
+    resolve_display_tz,
+)
+
+__all__ = [
+    "DISPLAY_TZ_ENV_VAR",
+    "format_for_display",
+    "resolve_display_tz",
+]

--- a/src/maestro/analysis/timestamps.py
+++ b/src/maestro/analysis/timestamps.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import os
 import sys
 from datetime import datetime, timezone
-from typing import Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # Name of the environment variable that overrides the display timezone.
@@ -43,7 +42,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 ENV_VAR = "MAESTRO_DISPLAY_TZ"
 
 
-def resolve_display_tz(display_tz: Optional[str] = None) -> ZoneInfo | timezone:
+def resolve_display_tz(display_tz: str | None = None) -> ZoneInfo | timezone:
     """
     Resolve the timezone to use for display, applying the precedence
     chain documented at module level.
@@ -85,7 +84,7 @@ def resolve_display_tz(display_tz: Optional[str] = None) -> ZoneInfo | timezone:
 
 def format_for_display(
     utc_dt: datetime,
-    display_tz: Optional[str] = None,
+    display_tz: str | None = None,
     *,
     fmt: str = "%Y-%m-%d %H:%M %Z",
 ) -> str:

--- a/src/maestro/analysis/timestamps.py
+++ b/src/maestro/analysis/timestamps.py
@@ -1,0 +1,110 @@
+"""
+MAESTRO — Timezone-aware timestamp display helpers.
+
+The DB stores every timestamp in UTC ISO-8601 (see schemas.py:
+``RunConfig.timestamp`` and ``RunEnvironment.captured_at`` both default to
+``datetime.now(timezone.utc)``). That's the right canonical form for
+storage: unambiguous, sortable, replication-friendly.
+
+Display is a different concern. A researcher reading "did run #42 hit the
+US/China API peak?" wants the local wall-clock time, not UTC. This module
+converts the stored UTC datetimes to a configurable display timezone and
+formats them with an explicit abbreviation so the result is unambiguous
+when shared across timezones.
+
+Storage stays UTC; only display surfaces (analysis tables, plot axes, log
+output, CSV columns — once #19/#24 exist) call into here.
+
+## Configuration precedence
+
+1. ``display_tz`` kwarg passed to ``format_for_display`` / ``resolve_display_tz``
+   — for analysis CLIs that want to expose a ``--display-tz`` flag.
+2. ``MAESTRO_DISPLAY_TZ`` environment variable — for persistent dev-machine
+   config via ``.env`` (e.g. ``MAESTRO_DISPLAY_TZ=Europe/Zurich``).
+3. System local timezone (``datetime.now().astimezone().tzinfo``) — the
+   sensible default when neither override is set.
+
+If an explicit value is provided but malformed (typo, unknown zone), we
+fall back to UTC and emit a one-line stderr warning rather than crashing.
+A display-formatting bug shouldn't abort an analysis run.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Name of the environment variable that overrides the display timezone.
+# Documented here (not just inline) so future contributors can find it
+# by grepping for the constant rather than the literal string.
+ENV_VAR = "MAESTRO_DISPLAY_TZ"
+
+
+def resolve_display_tz(display_tz: Optional[str] = None) -> ZoneInfo | timezone:
+    """
+    Resolve the timezone to use for display, applying the precedence
+    chain documented at module level.
+
+    Returns a ``ZoneInfo`` for named zones (IANA database) or the
+    ``timezone`` instance for the system local zone. Both are
+    ``tzinfo`` subclasses, so callers can use the return value with
+    ``datetime.astimezone(tz)`` uniformly.
+    """
+    # 1. Explicit kwarg from a caller's CLI flag wins.
+    name = display_tz
+    # 2. Fall back to the env var.
+    if name is None:
+        name = os.environ.get(ENV_VAR)
+
+    if name:
+        try:
+            return ZoneInfo(name)
+        except ZoneInfoNotFoundError:
+            source = "argument" if display_tz else f"${ENV_VAR}"
+            print(
+                f"WARN: unknown timezone {name!r} from {source}; falling back to UTC.",
+                file=sys.stderr,
+            )
+            return timezone.utc
+
+    # 3. System local. ``datetime.now().astimezone()`` is the standard
+    #    idiom for "use the current process's local timezone" — it
+    #    yields a tzinfo whose ``tzname()`` resolves the local
+    #    abbreviation (CEST, PST, etc.) which we want in the output.
+    local_tz = datetime.now().astimezone().tzinfo
+    if local_tz is None:
+        # Vanishingly rare — only on systems where Python can't
+        # determine local TZ at all. Be explicit instead of returning
+        # None and letting astimezone() fail later.
+        return timezone.utc
+    return local_tz
+
+
+def format_for_display(
+    utc_dt: datetime,
+    display_tz: Optional[str] = None,
+    *,
+    fmt: str = "%Y-%m-%d %H:%M %Z",
+) -> str:
+    """
+    Convert a UTC datetime (as stored in the DB) into a human-readable
+    string in the resolved display timezone.
+
+    ``utc_dt`` may be timezone-aware (UTC) or naive — naive inputs are
+    treated as UTC, matching the storage assumption. This is permissive
+    on purpose: ISO-8601 strings from the DB round-trip through pydantic
+    as aware datetimes, but downstream code that parses them with
+    ``datetime.fromisoformat`` on Python 3.10 can produce naive objects
+    on edge cases.
+
+    Default ``fmt`` includes ``%Z`` so the output carries the zone
+    abbreviation (e.g. ``2026-05-08 23:43 CEST``) — explicit timezones
+    in shared results matter more than character count.
+    """
+    if utc_dt.tzinfo is None:
+        utc_dt = utc_dt.replace(tzinfo=timezone.utc)
+    local = utc_dt.astimezone(resolve_display_tz(display_tz))
+    return local.strftime(fmt)

--- a/src/maestro/db/environment.py
+++ b/src/maestro/db/environment.py
@@ -45,6 +45,11 @@ _LIB_WHITELIST: tuple[str, ...] = (
     "langgraph",
     "pydantic",
     "python-dotenv",
+    # Windows-only via env marker in pyproject.toml. On Linux/macOS this
+    # will record as None (not installed), which is correct — the system
+    # zoneinfo DB is in use there. On Windows, recording the tzdata wheel
+    # version closes the reproducibility loop for timestamp display.
+    "tzdata",
 )
 
 

--- a/tests/analysis/test_timestamps.py
+++ b/tests/analysis/test_timestamps.py
@@ -32,7 +32,10 @@ def test_explicit_tz_arg_wins(monkeypatch):
     # 21:43 UTC + 2h DST = 23:43 CEST
     assert "23:43" in out
     assert "CEST" in out
-    assert "Tokyo" not in out  # env var was ignored
+    # %Z produces zone abbreviations, not full names — assert the
+    # abbreviation Asia/Tokyo *would* have produced is absent, which
+    # is the meaningful "env var was ignored" check.
+    assert "JST" not in out
 
 
 def test_env_var_used_when_arg_absent(monkeypatch):
@@ -59,13 +62,31 @@ def test_system_local_default(monkeypatch):
 
 
 def test_malformed_tz_falls_back_to_utc(monkeypatch, capsys):
-    """An unknown zone name produces UTC + a stderr warning."""
+    """An unknown zone name (via kwarg) produces UTC + a stderr warning."""
     out = format_for_display(SUMMER_UTC, display_tz="Mars/Olympus_Mons")
     assert "UTC" in out
     assert "21:43" in out  # unchanged because UTC
     captured = capsys.readouterr()
     assert "WARN" in captured.err
     assert "Mars/Olympus_Mons" in captured.err
+    # The warning identifies the source as "argument" (the kwarg path).
+    assert "argument" in captured.err
+
+
+def test_malformed_env_var_falls_back_to_utc(monkeypatch, capsys):
+    """A malformed MAESTRO_DISPLAY_TZ takes the env-var branch of the
+    warning code path — different stderr text than the kwarg branch."""
+    monkeypatch.setenv(ENV_VAR, "Mars/Olympus_Mons")
+    out = format_for_display(SUMMER_UTC)
+    assert "UTC" in out
+    assert "21:43" in out
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert "Mars/Olympus_Mons" in captured.err
+    # The warning identifies the source as the env-var name, so the
+    # user knows where to look. Distinguishes from the kwarg branch
+    # above which says "argument".
+    assert f"${ENV_VAR}" in captured.err
 
 
 def test_naive_input_treated_as_utc():

--- a/tests/analysis/test_timestamps.py
+++ b/tests/analysis/test_timestamps.py
@@ -1,0 +1,111 @@
+"""
+Tests for the display-timezone helpers.
+
+The helpers convert UTC datetimes (the DB's storage form) into
+human-readable strings in a configurable timezone, used at analysis
+display time. Storage stays UTC; this module only governs presentation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from maestro.analysis.timestamps import (
+    ENV_VAR,
+    format_for_display,
+    resolve_display_tz,
+)
+
+# A fixed UTC moment used as the input across most cases. Using a
+# concrete instant (mid-summer in the northern hemisphere, where Europe
+# is on CEST = UTC+2) makes the expected output predictable.
+SUMMER_UTC = datetime(2026, 6, 15, 21, 43, 0, tzinfo=timezone.utc)
+
+
+def test_explicit_tz_arg_wins(monkeypatch):
+    """The display_tz kwarg overrides the env var."""
+    monkeypatch.setenv(ENV_VAR, "Asia/Tokyo")
+    out = format_for_display(SUMMER_UTC, display_tz="Europe/Zurich")
+    # 21:43 UTC + 2h DST = 23:43 CEST
+    assert "23:43" in out
+    assert "CEST" in out
+    assert "Tokyo" not in out  # env var was ignored
+
+
+def test_env_var_used_when_arg_absent(monkeypatch):
+    """MAESTRO_DISPLAY_TZ is honoured when no explicit arg is given."""
+    monkeypatch.setenv(ENV_VAR, "Europe/Zurich")
+    out = format_for_display(SUMMER_UTC)
+    assert "23:43" in out
+    assert "CEST" in out
+
+
+def test_system_local_default(monkeypatch):
+    """No arg, no env var → falls back to system local without crashing.
+
+    We can't pin the exact output because the test runner's local zone
+    varies, but the call must produce *some* well-formed string with
+    a zone abbreviation in it.
+    """
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    out = format_for_display(SUMMER_UTC)
+    assert "2026-06-15" in out
+    # Should contain *some* zone abbreviation token — not literally
+    # checking which one because that depends on the runner.
+    assert len(out.split()) >= 3  # date + time + zone abbr
+
+
+def test_malformed_tz_falls_back_to_utc(monkeypatch, capsys):
+    """An unknown zone name produces UTC + a stderr warning."""
+    out = format_for_display(SUMMER_UTC, display_tz="Mars/Olympus_Mons")
+    assert "UTC" in out
+    assert "21:43" in out  # unchanged because UTC
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert "Mars/Olympus_Mons" in captured.err
+
+
+def test_naive_input_treated_as_utc():
+    """
+    Datetimes that lost their tzinfo (e.g. via fromisoformat edge
+    cases) are interpreted as UTC, matching the DB storage assumption.
+    """
+    naive = SUMMER_UTC.replace(tzinfo=None)
+    out_aware = format_for_display(SUMMER_UTC, display_tz="Europe/Zurich")
+    out_naive = format_for_display(naive, display_tz="Europe/Zurich")
+    assert out_aware == out_naive
+
+
+def test_resolve_display_tz_returns_zoneinfo_for_named_zone(monkeypatch):
+    """resolve_display_tz should produce a usable tzinfo object."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    tz = resolve_display_tz("Europe/Zurich")
+    assert isinstance(tz, ZoneInfo)
+    # Round-trip a datetime through it to prove it's wired correctly.
+    converted = SUMMER_UTC.astimezone(tz)
+    assert converted.hour == 23
+
+
+@pytest.mark.parametrize(
+    "tz_name,expected_hour,expected_abbr",
+    [
+        ("UTC", 21, "UTC"),
+        ("Europe/Zurich", 23, "CEST"),  # UTC+2 in summer
+        ("America/Los_Angeles", 14, "PDT"),  # UTC-7 in summer
+        ("Asia/Tokyo", 6, "JST"),  # UTC+9, next-day clock (Jun 16 06:43)
+    ],
+)
+def test_known_zones_convert_correctly(
+    tz_name: str, expected_hour: int, expected_abbr: str
+):
+    """Spot-check a handful of zones against known DST offsets."""
+    out = format_for_display(SUMMER_UTC, display_tz=tz_name)
+    assert f"{expected_hour:02d}:43" in out, (
+        f"expected {expected_hour:02d}:43 in output for {tz_name}, got: {out}"
+    )
+    assert expected_abbr in out, (
+        f"expected '{expected_abbr}' in output for {tz_name}, got: {out}"
+    )


### PR DESCRIPTION
## Summary
Adds `maestro.analysis.timestamps` with `format_for_display` / `resolve_display_tz` so analysis output can render the DB's UTC timestamps in any timezone. Storage stays UTC ISO-8601 (per issue scope); only display converts.

Precedence: explicit `display_tz` kwarg > `MAESTRO_DISPLAY_TZ` env var > system local > UTC fallback (with stderr warning on malformed values).

No existing call sites updated — the analysis output surface (#19, #24) doesn't exist yet. This PR ships the helper so those follow-up PRs can import it cold rather than figuring out timezone handling mid-feature.

Closes #14.

## Test plan
- [x] `pytest -v` — 19/19 passing (10 new tests covering precedence, fallback, naive input, DST-aware known zones)
- [x] Visual check: yesterday's sop_based run (UTC 23:25:06) renders as `2026-05-27 01:25 CEST` in Europe/Zurich, `2026-05-26 16:25 PDT` in America/Los_Angeles, `2026-05-27 07:25 CST` in Asia/Shanghai
- [x] `ruff check` + `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## TLDR
Adds timezone-aware timestamp display helpers for analysis output. UTC storage remains unchanged; only display conversion is performed. New `format_for_display()` and `resolve_display_tz()` functions in `maestro.analysis.timestamps` with configurable timezone precedence (explicit arg > env var > system local > UTC fallback). Default format includes timezone abbreviation. Comprehensive test coverage (19 tests) included. Closes `#14`.

## Overview
This PR implements a small helper module (`src/maestro/analysis/timestamps.py`) to convert UTC datetimes from the database to configurable local timezones for analysis output surfaces (tables, plots, logs, CSVs).

## Key Changes

**New Module: `src/maestro/analysis/timestamps.py`**
- `resolve_display_tz(display_tz=None)` – Selects the display timezone via precedence: explicit `display_tz` kwarg > `MAESTRO_DISPLAY_TZ` environment variable > system local timezone > UTC fallback
- `format_for_display(utc_dt, display_tz=None, *, fmt="%Y-%m-%d %H:%M %Z")` – Converts UTC datetime to the resolved display timezone and formats it (default includes timezone abbreviation)
- Malformed timezone names emit a one-line stderr warning and fall back to UTC instead of raising an exception
- Naive (tzinfo-less) datetimes are treated as UTC

**Package Exports**
- Updated `src/maestro/analysis/__init__.py` to re-export `DISPLAY_TZ_ENV_VAR`, `resolve_display_tz`, and `format_for_display`

**Dependencies & Tooling**
- Added `tzdata; sys_platform == 'win32'` to `pyproject.toml` to ensure `zoneinfo` named timezones are available on Windows
- Updated `src/maestro/db/environment.py` to include `tzdata` in dependency version tracking

**Test Coverage**
- Added `tests/analysis/test_timestamps.py` with 19 comprehensive tests covering:
  - Timezone precedence (kwarg over env var, env var over system local)
  - UTC fallback with stderr warning for malformed values
  - Naive datetime handling and DST-aware zones
  - Correct hour and timezone abbreviation outputs across multiple zones

## Status
- All tests passing (19/19)
- Code quality checks clean (ruff, formatting)
- Reviewer feedback applied (modern type hints, import organization, additional test coverage)
- No existing call sites updated; helper is ready for integration into future analysis output surfaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Colinho22/maestro/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->