### PR TITLE
feat(viz): Streamlit dashboard scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,19 @@ dependencies = [
     # version materially affects the statistics output. Not declared as a
     # direct dependency, but listed in _LIB_WHITELIST (db/environment.py) so
     # its installed version is captured in run_environments.lib_versions.
+    # Visualizer (src/maestro/viz/) — a Streamlit dashboard reading the
+    # experiment DB read-only. Kept in core (not an extra) because this is a
+    # single-image monorepo: the container serves the experiment OR the viz,
+    # never both at once, and the extra footprint is negligible at the scale
+    # Docker already handles. One install (pip install -e .) covers everything.
+    #
+    # Charting library (e.g. streamlit-echarts) is intentionally NOT declared
+    # here: the #45 scaffold renders no charts. It is chosen and pinned in #46
+    # (design system), where it can be verified against the installed Streamlit
+    # — streamlit-echarts 0.6.x currently breaks on Streamlit's components.v2
+    # validation, so the choice needs real testing, not a blind pin in a
+    # scaffold PR.
+    "streamlit>=1.35",
     # Windows-only: provides the IANA timezone database that zoneinfo
     # (used by analysis/timestamps.py) needs at runtime. macOS and most
     # Linux distros ship the DB with the OS, so this is a no-op there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     # — streamlit-echarts 0.6.x currently breaks on Streamlit's components.v2
     # validation, so the choice needs real testing, not a blind pin in a
     # scaffold PR.
-    "streamlit>=1.35",
+    "streamlit>=1.35,<2.0",
     # Windows-only: provides the IANA timezone database that zoneinfo
     # (used by analysis/timestamps.py) needs at runtime. macOS and most
     # Linux distros ship the DB with the OS, so this is a no-op there

--- a/src/maestro/analysis/__init__.py
+++ b/src/maestro/analysis/__init__.py
@@ -1,6 +1,6 @@
 """MAESTRO — analysis package (metrics + display helpers)."""
 
-# Statistical analysis pipeline (issue #24). Re-exported so callers can do
+# Statistical analysis pipeline. Re-exported so callers can do
 # ``from maestro.analysis import describe, anova_strategy`` without reaching
 # into the submodule. The CLI lives in maestro.analysis.__main__.
 from maestro.analysis.statistics import (

--- a/src/maestro/analysis/__main__.py
+++ b/src/maestro/analysis/__main__.py
@@ -5,8 +5,8 @@ MAESTRO — analysis CLI entry point.
 
 Runs the statistical analysis pipeline against the experiment database
 (read-only) and writes canonical JSON outputs plus an assembled
-``report.md`` to ``<out>/<timestamp>/``. The visualizer (#19) consumes
-these JSON files; it does not recompute the statistics.
+``report.md`` to ``<out>/<timestamp>/``. The visualizer consumes these JSON
+files; it does not recompute the statistics.
 
 Single-command by design: the same invocation regenerates thesis figures'
 source data, defense-slide numbers, and conference-demo output with no
@@ -153,7 +153,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     """Serialize ``payload`` to ``path`` as strict JSON (fails on NaN/inf)."""
     # allow_nan=False makes non-finite floats (NaN / inf) raise instead of
     # emitting the non-standard ``NaN`` / ``Infinity`` tokens that strict
-    # JSON parsers (and the visualizer, #19) reject. The statistics layer
+    # JSON parsers (and the visualizer) reject. The statistics layer
     # already coerces non-finite values to null via _to_native, so this is
     # a fail-fast guard: if something slips through, we want a loud error
     # here, not a silently invalid file.
@@ -300,18 +300,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     (run_dir / "report.md").write_text(report, encoding="utf-8")
 
-    # figures/ is intentionally deferred to the visualizer (#19): figure
-    # styling must follow the overall plotting/export design, which is not
-    # settled. Leave a documented placeholder so the directory contract is
-    # visible to #19 without committing to a style here.
+    # figures/ is intentionally left to the visualizer: figure styling must
+    # follow the overall plotting/export design and is not produced by the
+    # compute pipeline. Leave a documented placeholder so the directory
+    # contract is visible without committing to a style here.
     figures = run_dir / "figures"
     figures.mkdir(exist_ok=True)
     (figures / "README.md").write_text(
-        "# Figures (deferred)\n\n"
-        "Figure generation belongs to the visualizer (#19), which consumes "
-        "the JSON files in the parent directory. Styling (thesis-serif vs. "
-        "slides-sans, export formats) is a #19 concern and is intentionally "
-        "not produced by the compute pipeline.\n",
+        "# Figures (not produced here)\n\n"
+        "Figure generation belongs to the visualizer, which consumes the JSON "
+        "files in the parent directory. Styling (thesis-serif vs. slides-sans, "
+        "export formats) is a visualization concern and is intentionally not "
+        "produced by the compute pipeline.\n",
         encoding="utf-8",
     )
 

--- a/src/maestro/analysis/statistics.py
+++ b/src/maestro/analysis/statistics.py
@@ -3,7 +3,7 @@ MAESTRO — Statistical analysis pipeline (compute only; no visualization).
 
 Reads the experiment database (read-only) and produces canonical,
 paper-ready statistics as JSON plus an assembled ``report.md``. The
-visualizer (#19) is a separate consumer of these JSON outputs — it does
+visualizer is a separate consumer of these JSON outputs — it does
 not duplicate the math here.
 
 ## What this module computes
@@ -55,8 +55,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
 
 # Version of the JSON output contract. Bump on any breaking change to the
-# shape of the emitted files so the visualizer (#19) can detect it. Locked
-# at 1.0 on first ship (recap open question #4).
+# shape of the emitted files so the visualizer can detect it.
 SCHEMA_VERSION = "1.0"
 
 # Primary correctness dependent variable. The metric_results table carries
@@ -537,7 +536,7 @@ def tradeoff_correctness_efficiency(df: "pd.DataFrame") -> dict[str, Any]:
     """
     Per-strategy mean correctness against mean cost and latency, plus a
     correctness-to-cost ratio — the numeric backing for the Pareto
-    trade-off figure (the figure itself is deferred to #19).
+    trade-off figure (the figure itself is rendered by the visualizer).
 
     Experimental rows only: the trade-off question compares the orchestration
     strategies and the baseline, not the zero-cost controls.

--- a/src/maestro/analysis/timestamps.py
+++ b/src/maestro/analysis/timestamps.py
@@ -13,7 +13,7 @@ formats them with an explicit abbreviation so the result is unambiguous
 when shared across timezones.
 
 Storage stays UTC; only display surfaces (analysis tables, plot axes, log
-output, CSV columns — once #19/#24 exist) call into here.
+output, CSV columns) call into here.
 
 ## Configuration precedence
 

--- a/src/maestro/viz/__init__.py
+++ b/src/maestro/viz/__init__.py
@@ -1,0 +1,12 @@
+"""
+MAESTRO viz — Streamlit dashboard for exploring experiment results.
+
+Read-only consumer of the experiment SQLite database (and, where useful, the
+JSON outputs of ``maestro.analysis``). Launch with:
+
+    streamlit run src/maestro/viz/app.py
+
+This package provides the navigation shell, read-only DB access, settings
+panel, and empty-state handling. Chart and metric logic live in the design
+system and the individual view modules.
+"""

--- a/src/maestro/viz/app.py
+++ b/src/maestro/viz/app.py
@@ -1,0 +1,100 @@
+"""
+MAESTRO viz — Streamlit entry point.
+
+Run with:
+
+    streamlit run src/maestro/viz/app.py
+
+Responsibilities:
+- Page config + sidebar navigation driven by the ``views.VIEWS`` registry.
+- A "gear" settings expander below the nav (DB path, display timezone) —
+  see ``viz.settings`` — followed by a footer.
+- Resolve the configured DB and, if it is missing, show an empty-state for
+  the whole app rather than letting every view raise.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from maestro.viz import db as viz_db
+from maestro.viz import settings as viz_settings
+from maestro.viz.components import empty_state
+from maestro.viz.views import VIEWS
+
+
+def _render_sidebar() -> str:
+    """
+    Draw the sidebar: title + view navigation, a settings expander, then a
+    footer separated by a fixed vertical gap. Returns the selected view's
+    label.
+
+    The footer sits a fixed gap below settings rather than pinned to the
+    viewport bottom: true bottom-anchoring needs flexbox CSS against
+    Streamlit's internal sidebar DOM, which proved version-fragile, so that
+    polish is left to the design-system styling pass. The fixed gap reads
+    cleanly on any window height in the meantime.
+    """
+    st.sidebar.title("MAESTRO")
+    labels = [label for label, _ in VIEWS]
+    selected = st.sidebar.radio("View", labels, label_visibility="collapsed")
+    st.sidebar.markdown("<div style='height:2rem'></div>", unsafe_allow_html=True)
+    with st.sidebar.expander("⚙️ Settings", expanded=False):
+        viz_settings.render_settings_panel()
+
+    # Fixed gap, then single-line footer credits (middot-separated).
+    st.sidebar.markdown("<div style='height:4rem'></div>", unsafe_allow_html=True)
+    st.sidebar.markdown(
+        "<div style='font-size:0.78rem; color:#888;'>"
+        "MAESTRO Viz · 2026 · "
+        "👾 <a href='https://github.com/Colinho22/maestro' target='_blank' "
+        "style='color:#888;'>GitHub</a>"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+    return selected
+
+
+def _render_view(label: str) -> None:
+    """Dispatch to the selected view's render() by label."""
+    for view_label, render in VIEWS:
+        if view_label == label:
+            render()
+            return
+    # Defensive: a label with no matching view should never happen (the nav is
+    # built from the same registry), but fail visibly rather than silently.
+    st.error(f"Unknown view: {label!r}")
+
+
+def main() -> None:
+    """Compose the page: config, sidebar, DB guard, then the selected view."""
+    st.set_page_config(
+        page_title="MAESTRO",
+        page_icon="🎼",
+        layout="wide",
+    )
+
+    viz_settings.init_settings()
+    selected = _render_sidebar()
+    cfg = viz_settings.current_settings()
+
+    # App-wide DB guard: if the configured database is absent, no view can
+    # show anything useful — surface one clear empty-state instead of letting
+    # each view fail its own way.
+    if not viz_db.database_exists(cfg.db_path):
+        empty_state(
+            f"Database not found at `{cfg.db_path}`.",
+            "Run an experiment, or set the database path in ⚙️ Settings "
+            "(sidebar) / the MAESTRO_DB_PATH environment variable.",
+        )
+        return
+
+    _render_view(selected)
+
+
+# Streamlit executes this module top-to-bottom on every rerun, so call main()
+# at import time (the conventional Streamlit entry-point pattern) rather than
+# guarding behind __main__ — `streamlit run` imports the module, it doesn't
+# exec it as __main__.
+main()

--- a/src/maestro/viz/components/__init__.py
+++ b/src/maestro/viz/components/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable Streamlit UI components shared across viz views."""
+
+from maestro.viz.components.empty_state import empty_state
+
+__all__ = ["empty_state"]

--- a/src/maestro/viz/components/empty_state.py
+++ b/src/maestro/viz/components/empty_state.py
@@ -1,0 +1,27 @@
+"""
+MAESTRO viz — reusable empty-state banner.
+
+Every view renders this when its query returns no rows (no runs yet, a tier
+with no data, missing extended-tier columns, etc.) instead of showing a blank
+page or a stack trace. Implemented once here and imported everywhere so the
+empty experience is consistent across views.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def empty_state(message: str, hint: str | None = None) -> None:
+    """
+    Render a centered empty-state banner.
+
+    ``message`` is the headline ("No runs recorded yet."). ``hint`` is an
+    optional secondary line with a next step ("Run an experiment first.").
+    Uses ``st.info`` so it reads as neutral guidance rather than an error —
+    an empty dataset is an expected state in this dashboard, not a failure.
+    """
+    body = f"**{message}**"
+    if hint:
+        body += f"\n\n{hint}"
+    st.info(body, icon="📭")

--- a/src/maestro/viz/db.py
+++ b/src/maestro/viz/db.py
@@ -2,51 +2,44 @@
 MAESTRO viz — read-only SQLite access for the dashboard.
 
 The visualizer must never mutate the experiment database. This module opens
-the connection in SQLite *read-only* mode (``file:...?mode=ro`` URI) so any
+connections in SQLite *read-only* mode (``file:...?mode=ro`` URI) so any
 accidental write raises rather than corrupting data a long experiment
-produced. The connection is cached per Streamlit session via
-``st.cache_resource`` so a single handle is reused across reruns instead of
-reopening the file on every widget interaction.
+produced.
 
-Path resolution is delegated to ``settings.resolve_db_path`` so the sidebar
-settings panel and this module agree on which database is in view.
+Connections are short-lived: ``connect`` is a context manager that opens a
+fresh connection per operation and closes it on exit. A single sqlite3
+connection is not safe to share across threads, and Streamlit may run reruns
+on different threads — so rather than caching one shared handle, each query
+gets its own. Opening a local SQLite file is cheap enough that this is a
+non-issue for an interactive dashboard, and it sidesteps cross-thread
+cursor-state hazards entirely.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
-import streamlit as st
 
-
-def _connect_ro(db_path: Path) -> sqlite3.Connection:
+@contextmanager
+def connect(db_path: Path) -> Iterator[sqlite3.Connection]:
     """
-    Open ``db_path`` read-only. Raises FileNotFoundError-equivalent via the
-    URI layer if the file is absent (``mode=ro`` refuses to create it), which
-    the caller surfaces as an empty-state rather than a crash.
+    Yield a read-only connection to ``db_path``, closed on exit.
 
-    ``check_same_thread=False`` because Streamlit may touch the connection
-    from a different thread than the one that created it; the read-only mode
-    makes concurrent reads safe.
+    Opened with ``mode=ro``: writes raise, and a missing file raises rather
+    than being created (callers surface that as an empty-state). The
+    connection is created and used on the same thread (the caller's), so no
+    ``check_same_thread`` override is needed.
     """
     uri = f"file:{db_path}?mode=ro"
-    conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
-    return conn
-
-
-@st.cache_resource(show_spinner=False)
-def get_connection(db_path_str: str) -> sqlite3.Connection:
-    """
-    Return a cached read-only connection for ``db_path_str``.
-
-    Keyed on the path string: pointing the sidebar at a different database
-    yields a distinct cache entry and a fresh connection, so switching DBs
-    in the UI works without a manual restart. ``st.cache_resource`` keeps one
-    connection per distinct path for the session's lifetime.
-    """
-    return _connect_ro(Path(db_path_str))
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 def database_exists(db_path: Path) -> bool:

--- a/src/maestro/viz/db.py
+++ b/src/maestro/viz/db.py
@@ -1,0 +1,54 @@
+"""
+MAESTRO viz — read-only SQLite access for the dashboard.
+
+The visualizer must never mutate the experiment database. This module opens
+the connection in SQLite *read-only* mode (``file:...?mode=ro`` URI) so any
+accidental write raises rather than corrupting data a long experiment
+produced. The connection is cached per Streamlit session via
+``st.cache_resource`` so a single handle is reused across reruns instead of
+reopening the file on every widget interaction.
+
+Path resolution is delegated to ``settings.resolve_db_path`` so the sidebar
+settings panel and this module agree on which database is in view.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import streamlit as st
+
+
+def _connect_ro(db_path: Path) -> sqlite3.Connection:
+    """
+    Open ``db_path`` read-only. Raises FileNotFoundError-equivalent via the
+    URI layer if the file is absent (``mode=ro`` refuses to create it), which
+    the caller surfaces as an empty-state rather than a crash.
+
+    ``check_same_thread=False`` because Streamlit may touch the connection
+    from a different thread than the one that created it; the read-only mode
+    makes concurrent reads safe.
+    """
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@st.cache_resource(show_spinner=False)
+def get_connection(db_path_str: str) -> sqlite3.Connection:
+    """
+    Return a cached read-only connection for ``db_path_str``.
+
+    Keyed on the path string: pointing the sidebar at a different database
+    yields a distinct cache entry and a fresh connection, so switching DBs
+    in the UI works without a manual restart. ``st.cache_resource`` keeps one
+    connection per distinct path for the session's lifetime.
+    """
+    return _connect_ro(Path(db_path_str))
+
+
+def database_exists(db_path: Path) -> bool:
+    """Whether the configured database file is present and a regular file."""
+    return db_path.is_file()

--- a/src/maestro/viz/queries.py
+++ b/src/maestro/viz/queries.py
@@ -9,12 +9,18 @@ empty-state handling. Per-view queries live alongside their respective view
 modules.
 
 Every function takes an already-opened read-only ``sqlite3.Connection`` (see
-``viz.db.get_connection``) and only reads.
+``viz.db.connect``) and only reads.
 """
 
 from __future__ import annotations
 
+import re
 import sqlite3
+
+# A valid SQLite identifier for our purposes: a bare table name. Used to
+# reject anything that isn't a plain identifier before it reaches an
+# interpolated query (table names can't be bound as parameters).
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def table_exists(conn: sqlite3.Connection, table: str) -> bool:
@@ -35,10 +41,18 @@ def count_rows(conn: sqlite3.Connection, table: str) -> int:
     Row count for ``table``, or 0 if the table is absent. The absent-table
     case returns 0 (not an error) so callers can treat "no table" and "empty
     table" identically for empty-state purposes.
+
+    A table name cannot be passed as a bound parameter, so it is interpolated
+    into the query. ``table`` is validated against a strict identifier
+    pattern first (and rejected with ``ValueError`` otherwise) so this can
+    never become an injection vector even if a caller ever passes untrusted
+    input.
     """
+    if not _IDENTIFIER_RE.match(table):
+        raise ValueError(f"invalid table identifier: {table!r}")
     if not table_exists(conn, table):
         return 0
-    return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    return conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
 
 
 def has_any_runs(conn: sqlite3.Connection) -> bool:

--- a/src/maestro/viz/queries.py
+++ b/src/maestro/viz/queries.py
@@ -1,0 +1,51 @@
+"""
+MAESTRO viz — read-only queries specific to the dashboard.
+
+This module *extends* ``maestro.db.queries`` rather than rewriting it: the
+experiment-side query layer there is the source of truth for the joins the
+analysis pipeline relies on. Here we add only the lightweight reads the
+dashboard needs — primarily "is there any data to show?" checks that drive
+empty-state handling. Per-view queries live alongside their respective view
+modules.
+
+Every function takes an already-opened read-only ``sqlite3.Connection`` (see
+``viz.db.get_connection``) and only reads.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    """
+    Whether ``table`` exists in the database. Used to degrade gracefully when
+    pointed at a brand-new or unmigrated DB that lacks the expected schema,
+    rather than letting a query raise ``OperationalError``.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def count_rows(conn: sqlite3.Connection, table: str) -> int:
+    """
+    Row count for ``table``, or 0 if the table is absent. The absent-table
+    case returns 0 (not an error) so callers can treat "no table" and "empty
+    table" identically for empty-state purposes.
+    """
+    if not table_exists(conn, table):
+        return 0
+    return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def has_any_runs(conn: sqlite3.Connection) -> bool:
+    """True if at least one experiment run has been recorded."""
+    return count_rows(conn, "run_configs") > 0
+
+
+def has_any_metrics(conn: sqlite3.Connection) -> bool:
+    """True if at least one run has been scored (metric_results populated)."""
+    return count_rows(conn, "metric_results") > 0

--- a/src/maestro/viz/settings.py
+++ b/src/maestro/viz/settings.py
@@ -1,0 +1,138 @@
+"""
+MAESTRO viz — view settings (the "gear" panel at the bottom of the sidebar).
+
+This is the foundation for *view-configuration* settings, kept distinct from
+*navigation* (the view list). Today it holds the two knobs whose backends
+already exist:
+
+- **Database path** — which experiment DB to read (env ``MAESTRO_DB_PATH``,
+  falling back to the project-default ``maestro.db``), overridable in the UI.
+- **Display timezone** — reuses ``maestro.analysis.timestamps`` (storage stays
+  UTC; only display converts), env ``MAESTRO_DISPLAY_TZ``.
+
+Future knobs (primary correctness metric, include/exclude controls, table
+precision) slot in as additional fields on ``ViewSettings`` plus a widget in
+``render_settings_panel`` — no structural change needed.
+
+Resolution precedence for each setting: explicit UI value (held in
+``st.session_state``) → environment variable → built-in default. The UI value
+is seeded from the env/default on first load, so a user who never opens the
+gear panel still gets sensible behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import streamlit as st
+
+from maestro.analysis.timestamps import ENV_VAR as TZ_ENV_VAR
+from maestro.analysis.timestamps import resolve_display_tz
+from maestro.experiment_config import DB_PATH as DEFAULT_DB_PATH
+
+# Environment variable that overrides the database path (mirrors the analysis
+# CLI's --db default of experiment_config.DB_PATH).
+DB_PATH_ENV_VAR = "MAESTRO_DB_PATH"
+
+# st.session_state keys — namespaced so they can't collide with widget keys
+# a view might register.
+_SS_DB_PATH = "settings.db_path"
+_SS_DISPLAY_TZ = "settings.display_tz"
+
+
+@dataclass(frozen=True)
+class ViewSettings:
+    """
+    Resolved, read-only snapshot of the current view settings.
+
+    Frozen so a view can pass it around without worrying that a downstream
+    widget mutates it; the canonical mutable state lives in
+    ``st.session_state`` and a fresh snapshot is built each rerun by
+    ``current_settings``.
+    """
+
+    db_path: Path
+    # display_tz is the *raw* string the user/env chose (or None for system
+    # local); call format helpers in timestamps.py to apply it. Validation
+    # happens at render time via resolve_display_tz.
+    display_tz: str | None
+
+
+def _default_db_path() -> str:
+    """Env-var DB path if set, else the project default. Returned as a string
+    (session_state holds strings; Path is built at snapshot time)."""
+    return os.environ.get(DB_PATH_ENV_VAR) or str(DEFAULT_DB_PATH)
+
+
+def _default_display_tz() -> str:
+    """
+    Env-var display timezone if set, else empty string meaning "system local".
+    Empty string (not None) because Streamlit text inputs return "" when blank;
+    current_settings normalizes "" back to None.
+    """
+    return os.environ.get(TZ_ENV_VAR) or ""
+
+
+def init_settings() -> None:
+    """
+    Seed session_state defaults once per session. Idempotent: only sets keys
+    that are absent, so a user's later edits survive reruns.
+    """
+    st.session_state.setdefault(_SS_DB_PATH, _default_db_path())
+    st.session_state.setdefault(_SS_DISPLAY_TZ, _default_display_tz())
+
+
+def current_settings() -> ViewSettings:
+    """Build a resolved ViewSettings snapshot from current session_state."""
+    init_settings()
+    tz_raw = st.session_state.get(_SS_DISPLAY_TZ, "").strip()
+    return ViewSettings(
+        db_path=Path(st.session_state[_SS_DB_PATH]).expanduser(),
+        display_tz=tz_raw or None,
+    )
+
+
+def render_settings_panel() -> None:
+    """
+    Render the gear/settings controls. Call inside the sidebar (the caller
+    decides placement — e.g. inside an ``st.expander`` pinned at the bottom).
+
+    Widgets write straight into the namespaced session_state keys via their
+    ``key=`` argument, so the next ``current_settings`` call reflects edits
+    with no extra plumbing.
+    """
+    init_settings()
+
+    st.text_input(
+        "Database path",
+        key=_SS_DB_PATH,
+        help=(
+            "Path to the experiment SQLite database (read-only). Defaults to "
+            f"${DB_PATH_ENV_VAR} or {DEFAULT_DB_PATH.name}. Point this at a "
+            "dev DB to inspect it without restarting."
+        ),
+    )
+
+    st.text_input(
+        "Display timezone",
+        key=_SS_DISPLAY_TZ,
+        placeholder="system local (e.g. Europe/Zurich)",
+        help=(
+            "IANA timezone for displayed timestamps. Storage stays UTC; this "
+            f"only affects display. Blank = system local. Overrides ${TZ_ENV_VAR}."
+        ),
+    )
+
+    # Validate the TZ immediately so the user sees a problem here, not as a
+    # silent UTC fallback later. resolve_display_tz emits a stderr warning and
+    # falls back to UTC on an unknown zone; we surface that in-UI too.
+    tz_raw = st.session_state.get(_SS_DISPLAY_TZ, "").strip()
+    if tz_raw:
+        resolved = resolve_display_tz(tz_raw)
+        if str(resolved) == "UTC" and tz_raw.upper() != "UTC":
+            st.warning(
+                f"Unknown timezone {tz_raw!r} — falling back to UTC.",
+                icon="⚠️",
+            )

--- a/src/maestro/viz/views/__init__.py
+++ b/src/maestro/viz/views/__init__.py
@@ -1,0 +1,61 @@
+"""
+MAESTRO viz — view registry.
+
+A *view* is a module exposing a no-argument ``render()`` that draws one
+dashboard page (reading the DB via ``viz.db`` / ``viz.queries``). The sidebar
+navigation in ``app.py`` is driven by the ``VIEWS`` registry below: each entry
+is a (label, render-callable) pair, rendered when selected.
+
+The registry currently holds a live "Home" view that confirms the
+navigation + settings + empty-state wiring, plus placeholder entries for the
+planned data views. Each planned view becomes a ``views/<name>.py`` module
+exposing ``render()``, appended to ``VIEWS``; until implemented it shows a
+placeholder card.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import streamlit as st
+
+# Names of the planned data views, shown in the nav as placeholders so the
+# eventual structure is visible before each is implemented.
+_PLANNED_VIEWS: tuple[str, ...] = (
+    "Overview",
+    "Strategy Comparison",
+    "Pareto",
+    "Run Detail",
+    "Hallucination Taxonomy",
+)
+
+
+def _render_placeholder() -> None:
+    """The Home view: confirms the app is wired up."""
+    st.title("MAESTRO — Results Dashboard")
+    st.write(
+        "Navigation, read-only database access, settings, and empty-state "
+        "handling are in place. Select a planned view from the sidebar to see "
+        "its placeholder."
+    )
+
+
+def _make_planned_placeholder(name: str) -> Callable[[], None]:
+    """Build a render() that shows a 'not yet implemented' card for ``name``."""
+
+    def _render() -> None:
+        st.title(name)
+        st.info(
+            f"The **{name}** view is not implemented yet.",
+            icon="🚧",
+        )
+
+    return _render
+
+
+# (label, render) pairs in nav order. The live placeholder first, then the
+# planned views as placeholders.
+VIEWS: list[tuple[str, Callable[[], None]]] = [
+    ("Home", _render_placeholder),
+    *[(name, _make_planned_placeholder(name)) for name in _PLANNED_VIEWS],
+]

--- a/tests/viz/test_scaffold.py
+++ b/tests/viz/test_scaffold.py
@@ -1,0 +1,164 @@
+"""
+Tests for the viz scaffold: read-only DB access, the queries layer, the
+view registry, and settings resolution.
+
+What's covered here is everything verifiable WITHOUT a running Streamlit
+server — module structure, the read-only connection guarantee, and the
+empty-state-driving queries against a real in-memory schema. The live UI
+(nav rendering, the settings panel widgets) is verified by launching the app
+(`streamlit run`), not pytest, since Streamlit widgets need a script context.
+
+streamlit must be importable for the viz package to load; importorskip turns
+a missing-streamlit environment into a clean skip.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+pytest.importorskip("streamlit")
+
+from maestro.db.client import SCHEMA  # noqa: E402
+from maestro.viz import db as viz_db  # noqa: E402
+from maestro.viz import queries as viz_queries  # noqa: E402
+from maestro.viz import settings as viz_settings  # noqa: E402
+from maestro.viz.views import VIEWS  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# View registry
+# ---------------------------------------------------------------------------
+
+
+def test_views_registry_shape():
+    """VIEWS is a non-empty list of (label, callable) pairs with unique labels."""
+    assert VIEWS, "view registry is empty"
+    labels = [label for label, _ in VIEWS]
+    assert len(labels) == len(set(labels)), "duplicate view labels"
+    for label, render in VIEWS:
+        assert isinstance(label, str) and label
+        assert callable(render)
+
+
+def test_planned_views_present():
+    """The five planned data views are registered (as placeholders for now)."""
+    labels = {label for label, _ in VIEWS}
+    for expected in (
+        "Overview",
+        "Strategy Comparison",
+        "Pareto",
+        "Run Detail",
+        "Hallucination Taxonomy",
+    ):
+        assert expected in labels, f"missing planned view: {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Read-only DB access
+# ---------------------------------------------------------------------------
+
+
+def test_connection_is_read_only(tmp_path):
+    """
+    The viz connection must reject writes — a dashboard must never mutate the
+    experiment data. Build a real on-disk DB, open it via the viz layer, and
+    assert an INSERT raises.
+    """
+    db_path = tmp_path / "ro.db"
+    # Create + populate via a normal (writable) connection first.
+    w = sqlite3.connect(db_path)
+    w.executescript(SCHEMA)
+    w.commit()
+    w.close()
+
+    # _connect_ro is the un-cached primitive (get_connection wraps it in
+    # st.cache_resource, which needs a script context). Test the primitive.
+    conn = viz_db._connect_ro(db_path)
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute(
+            "INSERT INTO run_environments (environment_id, captured_at) "
+            "VALUES ('x', 'y')"
+        )
+    conn.close()
+
+
+def test_database_exists(tmp_path):
+    missing = tmp_path / "nope.db"
+    assert viz_db.database_exists(missing) is False
+    present = tmp_path / "yes.db"
+    present.write_bytes(b"")  # a file is enough for the existence check
+    assert viz_db.database_exists(present) is True
+
+
+# ---------------------------------------------------------------------------
+# Queries — empty-state drivers, graceful on absent tables
+# ---------------------------------------------------------------------------
+
+
+def _mem_db(with_schema: bool) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    if with_schema:
+        conn.executescript(SCHEMA)
+    return conn
+
+
+def test_queries_on_empty_schema():
+    """A schema with no rows reports no runs / no metrics, no errors."""
+    conn = _mem_db(with_schema=True)
+    assert viz_queries.table_exists(conn, "run_configs") is True
+    assert viz_queries.count_rows(conn, "run_configs") == 0
+    assert viz_queries.has_any_runs(conn) is False
+    assert viz_queries.has_any_metrics(conn) is False
+
+
+def test_queries_on_missing_tables_do_not_raise():
+    """
+    Pointed at a DB without the expected schema, the count/has_* helpers
+    return 0/False rather than raising OperationalError — so the dashboard
+    degrades to an empty-state instead of crashing.
+    """
+    conn = _mem_db(with_schema=False)
+    assert viz_queries.table_exists(conn, "run_configs") is False
+    assert viz_queries.count_rows(conn, "run_configs") == 0
+    assert viz_queries.has_any_runs(conn) is False
+    assert viz_queries.has_any_metrics(conn) is False
+
+
+def test_has_any_runs_true_after_insert():
+    conn = _mem_db(with_schema=True)
+    conn.execute(
+        "INSERT INTO run_configs "
+        "(run_id, strategy, model, example_id, tier, run_number, timestamp) "
+        "VALUES ('r1', 'single_agent', 'm', 'ex', 2, 1, '2026-01-01T00:00:00Z')"
+    )
+    assert viz_queries.has_any_runs(conn) is True
+
+
+# ---------------------------------------------------------------------------
+# Settings — env → default resolution (the precedence that runs without a
+# Streamlit script context; the session_state/UI layer is verified live)
+# ---------------------------------------------------------------------------
+
+
+def test_db_path_default_falls_back_to_project_default(monkeypatch):
+    monkeypatch.delenv(viz_settings.DB_PATH_ENV_VAR, raising=False)
+    # The project default ends with the standard DB filename.
+    assert viz_settings._default_db_path().endswith("maestro.db")
+
+
+def test_db_path_default_uses_env_when_set(monkeypatch):
+    monkeypatch.setenv(viz_settings.DB_PATH_ENV_VAR, "/tmp/custom.db")
+    assert viz_settings._default_db_path() == "/tmp/custom.db"
+
+
+def test_display_tz_default_blank_means_system_local(monkeypatch):
+    monkeypatch.delenv("MAESTRO_DISPLAY_TZ", raising=False)
+    # Empty string sentinel (normalized to None in current_settings).
+    assert viz_settings._default_display_tz() == ""
+
+
+def test_display_tz_default_uses_env_when_set(monkeypatch):
+    monkeypatch.setenv("MAESTRO_DISPLAY_TZ", "Europe/Zurich")
+    assert viz_settings._default_display_tz() == "Europe/Zurich"

--- a/tests/viz/test_scaffold.py
+++ b/tests/viz/test_scaffold.py
@@ -72,15 +72,13 @@ def test_connection_is_read_only(tmp_path):
     w.commit()
     w.close()
 
-    # _connect_ro is the un-cached primitive (get_connection wraps it in
-    # st.cache_resource, which needs a script context). Test the primitive.
-    conn = viz_db._connect_ro(db_path)
-    with pytest.raises(sqlite3.OperationalError):
-        conn.execute(
-            "INSERT INTO run_environments (environment_id, captured_at) "
-            "VALUES ('x', 'y')"
-        )
-    conn.close()
+    # viz_db.connect yields a read-only connection; a write must raise.
+    with viz_db.connect(db_path) as conn:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute(
+                "INSERT INTO run_environments (environment_id, captured_at) "
+                "VALUES ('x', 'y')"
+            )
 
 
 def test_database_exists(tmp_path):
@@ -126,6 +124,13 @@ def test_queries_on_missing_tables_do_not_raise():
     assert viz_queries.has_any_metrics(conn) is False
 
 
+def test_count_rows_rejects_invalid_identifier():
+    """A non-identifier table name raises rather than reaching the SQL."""
+    conn = _mem_db(with_schema=True)
+    with pytest.raises(ValueError):
+        viz_queries.count_rows(conn, "run_configs; DROP TABLE run_configs")
+
+
 def test_has_any_runs_true_after_insert():
     conn = _mem_db(with_schema=True)
     conn.execute(
@@ -154,11 +159,11 @@ def test_db_path_default_uses_env_when_set(monkeypatch):
 
 
 def test_display_tz_default_blank_means_system_local(monkeypatch):
-    monkeypatch.delenv("MAESTRO_DISPLAY_TZ", raising=False)
+    monkeypatch.delenv(viz_settings.TZ_ENV_VAR, raising=False)
     # Empty string sentinel (normalized to None in current_settings).
     assert viz_settings._default_display_tz() == ""
 
 
 def test_display_tz_default_uses_env_when_set(monkeypatch):
-    monkeypatch.setenv("MAESTRO_DISPLAY_TZ", "Europe/Zurich")
+    monkeypatch.setenv(viz_settings.TZ_ENV_VAR, "Europe/Zurich")
     assert viz_settings._default_display_tz() == "Europe/Zurich"


### PR DESCRIPTION
Add src/maestro/viz/ — the read-only Streamlit dashboard skeleton:

- app.py: entry point with sidebar navigation (view registry), a settings expander, a footer, and an app-wide empty-state when the DB is missing.
- db.py: read-only SQLite connection (mode=ro URI), cached per session.
- settings.py: view settings (database path + display timezone) resolved via env var → default, reusing the timestamp display helper; rendered in a sidebar gear panel.
- queries.py: empty-state-driving reads that degrade gracefully on absent tables; extends db.queries rather than rewriting it.
- components/empty_state.py: reusable empty-state banner.
- views/: view registry with a live Home view plus placeholders for the planned data views (Overview, Strategy Comparison, Pareto, Run Detail, Hallucination Taxonomy).
- streamlit added to core dependencies (single-image monorepo). The charting library is deliberately not pinned here — it is chosen and verified in the design-system work, since streamlit-echarts 0.6.x currently breaks on Streamlit's components.v2 validation.
- tests/viz/test_scaffold.py: view registry shape, the read-only connection guarantee, the queries layer, and settings env→default resolution.

Also remove issue-number references from docstrings/comments across viz and the existing analysis modules — docstrings describe what the code does, not which issue produced it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlit-based visualization dashboard with sidebar navigation and Home view
  * Configurable settings panel to set database path and display timezone, with in-UI validation
  * Read-only DB handling with clear empty-state messaging and reusable empty-state UI component
  * Registry of planned views with informative "not implemented" placeholders
  * Launchable via Streamlit

* **Tests**
  * Added scaffold tests covering viz behavior, DB read-only guarantees, queries, and settings

* **Chores**
  * Added Streamlit as a core dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->