### PR TITLE
feat(viz): matplotlib design system per the visualization design guide

### DIFF
--- a/docs/visualization_design_guide.md
+++ b/docs/visualization_design_guide.md
@@ -1,0 +1,248 @@
+# Visualization Design Guide
+
+Standards for every chart in the thesis. The goal: any chart in the document reads consistently, encodes the right dimension on the right channel, and passes accessibility checks.
+
+This is a living document. Sections 1–4 are complete. Sections 5–6 are placeholders, to be filled in subsequent iterations.
+
+The canonical machine-readable form of the palettes and style lives in
+`src/maestro/viz/theme.py`. This document is the source of truth for the
+*intent*; `theme.py` implements it (keyed to the values the database stores
+via a mapping layer, since this guide names dimensions by their human display
+labels).
+
+---
+
+## 1. Color system
+
+Three independent dimensions need visual encoding: **provider** (which model family produces the diagram), **strategy** (which orchestration approach generates the diagram), and **tier** (input complexity). Each dimension gets its own visual signature so a reader can identify the encoded dimension at a glance. A separate sequential colormap handles continuous metrics.
+
+| Dimension | Encoding | Levels |
+|---|---|---|
+| Provider | Distinct hue per provider | 5 |
+| Provider × model | Lightness step within the provider hue | 2 per provider |
+| Strategy | Pink/magenta gradient | 4 |
+| Tier | Amber gradient | 3 (Tier 3 optional) |
+| Continuous metric (F1, cost, latency, …) | YlOrRd colormap | sequential |
+
+### 1.1 Provider palette
+
+Each provider gets one hue. Two lightness stops within that hue encode the two model variants used in the extended-tier experiment (smaller model vs flagship).
+
+| Provider | Light — smaller model | Dark — flagship |
+|---|---|---|
+| Claude | `#F0997B` | `#993C1D` |
+| ChatGPT | `#6B7280` | `#1F2937` |
+| Mistral | `#A78BFA` | `#5B21B6` |
+| Gemini | `#60A5FA` | `#1E40AF` |
+| DeepSeek | `#14B8A6` | `#115E59` |
+
+**Rationale.** Hues anchor to brand identity where contrast allows: Claude coral, OpenAI slate, Gemini blue, DeepSeek teal. Mistral pivots from yellow to violet because pure yellow fails WCAG contrast on white. The light-dark pair within each provider uses OKLCH lightness steps, which keep the perceived progression even across hues.
+
+**Known trade-off.** Mistral light (`#A78BFA`) and Gemini light (`#60A5FA`) sit close in color space. They appear next to each other only in charts that compare the smaller-model tier across providers, and alphabetical ordering places them adjacent. The dark stops separate cleanly, so flagship comparisons are unaffected. This affects at most one or two charts in the analysis.
+
+### 1.2 Strategy palette
+
+Four orchestration strategies on a single pink-to-magenta gradient. Lightness encodes structural explicitness — lighter for less explicit orchestration, darker for more explicit.
+
+| Strategy | Hex |
+|---|---|
+| Single Agent | `#ED93B1` |
+| SOP | `#D4537E` |
+| Crew AI | `#993556` |
+| LangGraph | `#72243E` |
+
+**Rationale.** Pink occupies a region of color space that no provider uses, which removes any chance of a reader confusing a strategy for a provider. The gradient implies ordering. Lightest is the single-LLM-call baseline, darkest is the explicit graph workflow.
+
+**The ordering is frozen.** Single Agent always gets `#ED93B1`, LangGraph always gets `#72243E`. Never reassign across charts.
+
+### 1.3 Tier palette
+
+Three input-complexity tiers on a light-to-dark amber gradient. Lightness encodes entity count.
+
+| Tier | Definition | Hex |
+|---|---|---|
+| 1 — Simple | < 10 entities | `#FAC775` |
+| 2 — Complex | 10–25 entities | `#BA7517` |
+| 3 — Cross-layer | 25+ entities (optional) | `#633806` |
+
+**Rationale.** Amber is the only major hue region not claimed by providers or strategies. The bronze-to-gold-to-brown progression maps intuitively to ascending tier. Tier 3 reserves a defined slot for the optional expansion analysis described in the proposal, so the palette never needs to shift if Tier 3 enters the analysis later.
+
+### 1.4 Continuous metric colormap
+
+Heatmaps and any other chart encoding a continuous metric (F1, cost, latency, hallucination rate) use a single shared colormap, separate from the categorical palettes above.
+
+**Colormap.** `YlOrRd` (matplotlib built-in). Light yellow at the low end, deep red at the high end. Reads as "intensity" and matches the conventional heat-map aesthetic.
+
+**Rules.**
+
+- Always include a colorbar with the metric name as the label.
+- Set `vmin` and `vmax` explicitly. For F1/accuracy use 0 and 1; for unbounded metrics use 0 and the maximum observed value.
+- Cell value annotations: compute luminance per cell and switch text color — white on dark cells, `#333333` on light cells.
+
+**Trade-off.** The dark-red zone of YlOrRd neighbors Claude's flagship coral (`#993C1D`). The colorbar disambiguates context, but avoid placing a YlOrRd heatmap directly next to a Claude-coral bar chart on the same page.
+
+### 1.5 Co-occurrence safety
+
+The 4×2 factorial design (strategy × tier) puts both palettes on the same chart often. Pink and amber sit on opposite sides of red in hue space. Even at their darkest stops — `#72243E` deep magenta vs `#633806` deep brown — they stay distinguishable under all common color-vision conditions.
+
+Providers and tiers can also co-occur (provider as bar group, tier as color, or vice versa). The amber gradient does not overlap with any provider hue.
+
+### 1.6 Accessibility
+
+- Every dark stop meets WCAG AA contrast (≥4.5:1) on white.
+- Every light stop meets AA Large (≥3:1) and the 3:1 non-text contrast threshold for chart fills.
+- Lightness alone preserves the ordering in each gradient. Charts remain readable when printed in grayscale.
+- Palettes were checked against deuteranopia, protanopia, and tritanopia simulations.
+
+### 1.7 Python palette dictionaries
+
+```python
+# Provider gradients
+# Each list: [smaller model, flagship]
+PROVIDER_TIERS = {
+    "Claude":   ["#F0997B", "#993C1D"],
+    "ChatGPT":  ["#6B7280", "#1F2937"],
+    "Mistral":  ["#A78BFA", "#5B21B6"],
+    "Gemini":   ["#60A5FA", "#1E40AF"],
+    "DeepSeek": ["#14B8A6", "#115E59"],
+}
+
+# Strategy gradient
+# Ordered: light = least explicit orchestration, dark = most explicit
+STRATEGY_COLORS = {
+    "Single Agent": "#ED93B1",
+    "SOP":          "#D4537E",
+    "Crew AI":      "#993556",
+    "LangGraph":    "#72243E",
+}
+
+# Tier gradient
+# Light = simple input, dark = complex input
+# Tier 3 reserved for optional expansion analysis
+TIER_COLORS = {
+    1: "#FAC775",
+    2: "#BA7517",
+    3: "#633806",
+}
+
+# Continuous metric colormap
+HEAT_COLORMAP = "YlOrRd"
+```
+
+---
+
+## 2. Typography
+
+One font everywhere. Hierarchy comes from weight and size, not from switching fonts. Mixing typefaces in a thesis figure looks unprofessional.
+
+**Font family.** Arial. On systems without Arial, fall back to Liberation Sans, then DejaVu Sans.
+
+**Sizes.**
+
+| Element | Size | Weight | Color |
+|---|---|---|---|
+| Body text (thesis prose) | 11pt | regular | `#000000` |
+| Axis title | 10pt | bold | `#000000` |
+| Tick labels | 9pt | regular | `#333333` |
+| Legend text | 9pt | regular | `#333333` |
+| In-chart annotations | 10pt | regular | `#333333` |
+| Chart title (slides / repo only) | 12pt | bold | `#000000` |
+
+**Chart titles.** Omit for figures inside the thesis PDF. The figure caption below the chart does the descriptive work. Include in-chart titles only for slide decks and the open-source repository's interactive views.
+
+**Color choice rationale.** Axis titles use pure black for emphasis (titles outrank values in hierarchy). Tick labels, legend text, and annotations use `#333333` — softer than pure black, matches the axis line color, prints cleanly without sharp edges on Arial's thin strokes at 9pt.
+
+---
+
+## 3. Background and layout
+
+**Default background.** White (`#FFFFFF`) for both the figure and the axes face. White prints cleanly and gives charts a neutral container regardless of where they end up — thesis PDF, slides, or the repo README.
+
+**Transparent background.** Use as a per-chart override when the chart sits on a colored slide background or when the chart type benefits from showing through (donut, sunburst, mockup overlays). Apply by setting `facecolor='none'` on both the figure and the axes.
+
+**Standard figure dimensions.**
+
+| Chart type | Size (inches) | Aspect |
+|---|---|---|
+| Standard chart | 9 × 4.5 | 2:1 |
+| Wide grouped bar (e.g., 5 providers × 2 models) | 10 × 4.5 | ~2.2:1 |
+| Heatmap | 5.5 × 5 | square-ish, scales with data shape |
+| Pareto scatter | 8 × 5 | 1.6:1 |
+| Tall vertical bar (≤4 categories) | 7 × 4.5 | ~1.6:1 |
+
+**Export resolution.** Save PNG at 200 DPI for slides and inline previews. Use SVG or PDF for thesis figures — vector formats scale without loss in the printed thesis.
+
+---
+
+## 4. Axes and gridlines
+
+**Frame.** L-shape — bottom and left spines only. Top and right hidden. Open and modern, the standard for scientific publication figures.
+
+**Spines and ticks.**
+
+- Spine line: 0.75pt, color `#333333`
+- Tick marks: outside the plot, 3pt long, major only
+- Tick line width matches the spine (0.75pt)
+- No minor ticks — they add visual noise at thesis-figure size without conveying useful detail
+
+**Tick labels.** Arial 9pt regular, color `#333333`. Default rotation 0°. Rotate 45° only when adjacent labels would overlap.
+
+**Axis titles.** Arial 10pt bold, color `#000000`. Always include units in parentheses when relevant — `"Latency (s)"`, `"Cost (USD)"`, `"Tokens (k)"`.
+
+**Gridlines.**
+
+- Color: `#D0D0D0`
+- Weight: 0.5pt
+- Style: solid (dashed reads as "uncertain" or "projected" — wrong signal for measured data)
+- Always behind the data (`axes.axisbelow = True`)
+
+**Gridline direction by chart type.**
+
+| Chart type | Horizontal | Vertical |
+|---|---|---|
+| Vertical bars | yes | no |
+| Horizontal bars | no | yes |
+| Line | yes | optional |
+| Area | yes | no |
+| Scatter / Pareto | yes | yes |
+| Heatmap | no | no — cells provide structure |
+
+**Heatmap exception.** Heatmaps get a full box frame (all four spines visible) instead of the L-shape, because cells need clear boundaries on all sides.
+
+**Linear vs log scale.**
+
+- Linear by default.
+- Log scale for metrics that span more than one order of magnitude — typically cost, latency, token count.
+- Always linear for bounded metrics (F1, accuracy, hallucination rate, percentages).
+- When using a log scale, annotate in the axis title: `"Cost in USD (log)"`.
+
+**Zero baseline.** Bar charts must start at 0. Truncating the bar baseline distorts visual comparison. Line charts may start above 0 when the data range is narrow and 0 carries no meaning (e.g., F1 between 0.7 and 0.9). Mention any truncation in the figure caption.
+
+**Number formatting.**
+
+- Thousands separator: comma — `1,000`
+- Currency: `$1.23` with 2 decimals
+- Time: with units inline — `"1.2 s"`, `"150 ms"`
+- Percentages: `87%` typically; `87.3%` only when small differences matter
+- F1 / accuracy: 2 decimals — `0.87`
+- Round consistently to avoid float artifacts
+
+---
+
+## 5. Legends
+
+*To be defined.* Topics to cover: position, ordering rules, in-legend vs in-chart labels, marker style (square / line / dot), frame on/off, when to omit the legend entirely.
+
+---
+
+## 6. Chart-type recipes
+
+*To be defined.* Topics to cover: which chart type fits which RQ (bar for category comparison, line for trends across input size, heatmap for the 4×2 factorial, Pareto scatter for RQ4 efficiency-vs-correctness), default configurations per recipe.
+
+---
+
+## Appendix — Reference Python configuration
+
+The `apply_thesis_style()` function in `src/maestro/viz/theme.py` configures
+every subsequent matplotlib chart from a single call. It mirrors the
+typography, axes, gridline, and background rules above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,13 @@ dependencies = [
     # never both at once, and the extra footprint is negligible at the scale
     # Docker already handles. One install (pip install -e .) covers everything.
     #
-    # Charting library (e.g. streamlit-echarts) is intentionally NOT declared
-    # here: the #45 scaffold renders no charts. It is chosen and pinned in #46
-    # (design system), where it can be verified against the installed Streamlit
-    # — streamlit-echarts 0.6.x currently breaks on Streamlit's components.v2
-    # validation, so the choice needs real testing, not a blind pin in a
-    # scaffold PR.
+    # Charts are rendered with matplotlib (displayed via st.pyplot), not a
+    # browser-component library: the thesis deliverable is static,
+    # publication-quality figures, and matplotlib gives one style system for
+    # both the dashboard and the embedded thesis figures with no
+    # browser-component fragility.
     "streamlit>=1.35,<2.0",
+    "matplotlib>=3.8",
     # Windows-only: provides the IANA timezone database that zoneinfo
     # (used by analysis/timestamps.py) needs at runtime. macOS and most
     # Linux distros ship the DB with the OS, so this is a no-op there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     # both the dashboard and the embedded thesis figures with no
     # browser-component fragility.
     "streamlit>=1.35,<2.0",
-    "matplotlib>=3.8",
+    "matplotlib>=3.8,<4",
     # Windows-only: provides the IANA timezone database that zoneinfo
     # (used by analysis/timestamps.py) needs at runtime. macOS and most
     # Linux distros ship the DB with the OS, so this is a no-op there

--- a/src/maestro/viz/chart.py
+++ b/src/maestro/viz/chart.py
@@ -1,0 +1,100 @@
+"""
+MAESTRO viz — matplotlib figure helpers for the dashboard.
+
+Two pieces every view uses:
+
+- ``new_figure`` — create a ``(fig, ax)`` with the house style applied, so a
+  view never has to remember to call ``apply_thesis_style`` itself.
+- ``render_chart`` — display a figure in Streamlit and offer PNG + SVG
+  downloads (publication-quality vector for the thesis, raster for slides).
+  It closes the figure afterwards: matplotlib keeps figures alive globally,
+  so a long-running dashboard that forgot to close them would leak memory.
+
+Export uses an in-memory buffer (no temp files), so it works regardless of
+the host OS or filesystem.
+"""
+
+from __future__ import annotations
+
+import io
+
+import matplotlib.pyplot as plt
+import streamlit as st
+from matplotlib.figure import Figure
+
+from maestro.viz.theme import apply_thesis_style
+
+
+def new_figure(
+    *,
+    figsize: tuple[float, float] = (7.0, 4.5),
+) -> tuple[Figure, plt.Axes]:
+    """
+    Return a themed ``(fig, ax)``. Applies the house style first (idempotent),
+    so callers get consistent typography/spines/grid without extra setup.
+
+    Default size is the design guide's "tall vertical bar" (7 × 4.5, ~1.6:1).
+    Views pick a size from the guide's figure-dimensions table to match their
+    chart type (e.g. 8 × 5 for Pareto scatter, 10 × 4.5 for wide grouped bars).
+    """
+    apply_thesis_style()
+    fig, ax = plt.subplots(figsize=figsize)
+    return fig, ax
+
+
+def _savefig_bytes(fig: Figure, fmt: str) -> bytes:
+    """Render ``fig`` to ``fmt`` (png/svg) bytes via an in-memory buffer."""
+    buf = io.BytesIO()
+    # bbox_inches='tight' trims surrounding whitespace so exported figures
+    # embed cleanly without manual cropping.
+    fig.savefig(buf, format=fmt, bbox_inches="tight", dpi=200)
+    return buf.getvalue()
+
+
+def render_chart(
+    fig: Figure,
+    *,
+    filename: str,
+    key: str,
+    caption: str | None = None,
+) -> None:
+    """
+    Display ``fig`` in Streamlit with PNG + SVG download buttons, then close
+    it.
+
+    ``filename`` is the download stem (no extension); ``key`` must be unique
+    per chart on a page (Streamlit requires distinct widget keys). ``caption``
+    is shown under the figure if given.
+
+    ``use_container_width=True`` makes the chart scale to its container rather
+    than render at the figure's native inches — so a wide-layout page does
+    not let the figure dictate the overall column width. Views can wrap this
+    call in an ``st.columns`` block to bound the chart's region further.
+    """
+    st.pyplot(fig, use_container_width=True)
+    if caption:
+        st.caption(caption)
+
+    png = _savefig_bytes(fig, "png")
+    svg = _savefig_bytes(fig, "svg")
+
+    col_png, col_svg = st.columns(2)
+    with col_png:
+        st.download_button(
+            "Download PNG",
+            data=png,
+            file_name=f"{filename}.png",
+            mime="image/png",
+            key=f"{key}-png",
+        )
+    with col_svg:
+        st.download_button(
+            "Download SVG",
+            data=svg,
+            file_name=f"{filename}.svg",
+            mime="image/svg+xml",
+            key=f"{key}-svg",
+        )
+
+    # Release the figure — matplotlib holds a global reference otherwise.
+    plt.close(fig)

--- a/src/maestro/viz/chart.py
+++ b/src/maestro/viz/chart.py
@@ -46,8 +46,13 @@ def _savefig_bytes(fig: Figure, fmt: str) -> bytes:
     """Render ``fig`` to ``fmt`` (png/svg) bytes via an in-memory buffer."""
     buf = io.BytesIO()
     # bbox_inches='tight' trims surrounding whitespace so exported figures
-    # embed cleanly without manual cropping.
-    fig.savefig(buf, format=fmt, bbox_inches="tight", dpi=200)
+    # embed cleanly without manual cropping. dpi applies only to raster (PNG):
+    # the guide's 200 DPI for slides/previews. SVG is vector, where dpi is a
+    # no-op, so it is omitted to avoid implying otherwise.
+    kwargs: dict = {"bbox_inches": "tight"}
+    if fmt == "png":
+        kwargs["dpi"] = 200
+    fig.savefig(buf, format=fmt, **kwargs)
     return buf.getvalue()
 
 

--- a/src/maestro/viz/charts_reference.py
+++ b/src/maestro/viz/charts_reference.py
@@ -1,0 +1,94 @@
+"""
+MAESTRO viz — reference chart.
+
+A single, complete chart that exercises the whole rendering path
+(query → themed figure → display + PNG/SVG export). It is the copy-paste
+starting point for the data views: a new view follows this exact shape —
+open a read-only connection, run a query, build a figure with ``new_figure``
+and the named palette, hand it to ``render_chart``.
+
+The chart itself — mean entity-ID F1 per strategy — is deliberately simple;
+its job is to prove the design system works end to end against real data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from maestro.viz import db as viz_db
+from maestro.viz import queries as viz_queries
+from maestro.viz.chart import new_figure, render_chart
+from maestro.viz.components import empty_state
+from maestro.viz.theme import strategy_color
+
+
+def render_reference_chart(db_path: Path) -> None:
+    """
+    Draw the reference chart for the database at ``db_path``.
+
+    Opens its own short-lived read-only connection (the standard per-view
+    pattern), queries mean entity-ID F1 per strategy, and renders a bar chart
+    colored by the strategy palette. Shows an empty-state if no metrics exist.
+    """
+    with viz_db.connect(db_path) as conn:
+        data = viz_queries.mean_entity_id_f1_by_strategy(conn)
+
+    if not data:
+        empty_state(
+            "No scored runs yet.",
+            "Run an experiment so metric results exist, then this chart populates.",
+        )
+        return
+
+    strategies = [row[0] for row in data]
+    scores = [row[1] for row in data]
+    colors = [strategy_color(s) for s in strategies]
+
+    fig, ax = new_figure()
+    # Fixed bar width (in category units, max 1.0) keeps a single bar from
+    # stretching edge-to-edge, and leaves even gaps once several strategies
+    # are present.
+    bars = ax.bar(strategies, scores, color=colors, width=0.6)
+    ax.set_ylabel("Entity-ID F1 (mean)")
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("Strategy")
+    # Pad the x-axis so a lone bar isn't flush against the spines.
+    ax.margins(x=0.3 if len(strategies) == 1 else 0.1)
+
+    # Place the strategy name *inside* the bar (white, vertically centered)
+    # when it's tall enough to hold the text, and drop the redundant x-axis
+    # tick label in that case. For short bars the name can't fit inside, so
+    # keep it on the axis below instead.
+    keep_xtick = []
+    for bar, name in zip(bars, strategies):
+        x = bar.get_x() + bar.get_width() / 2
+        if bar.get_height() >= 0.25:
+            ax.text(
+                x,
+                bar.get_height() / 2,
+                name,
+                ha="center",
+                va="center",
+                color="white",
+                fontweight="bold",
+            )
+            keep_xtick.append("")
+        else:
+            keep_xtick.append(name)
+    ax.set_xticks(range(len(strategies)))
+    ax.set_xticklabels(keep_xtick)
+
+    fig.tight_layout()
+
+    render_chart(
+        fig,
+        filename="entity_id_f1_by_strategy",
+        key="reference-chart",
+        caption="Reference chart — mean entity-ID F1 per strategy.",
+    )
+
+    st.caption(
+        "This is the design-system reference chart: the template the data views follow."
+    )

--- a/src/maestro/viz/charts_reference.py
+++ b/src/maestro/viz/charts_reference.py
@@ -15,13 +15,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import streamlit as st
-
 from maestro.viz import db as viz_db
 from maestro.viz import queries as viz_queries
 from maestro.viz.chart import new_figure, render_chart
 from maestro.viz.components import empty_state
-from maestro.viz.theme import strategy_color
+from maestro.viz.theme import strategy_color, strategy_display_name
 
 
 def render_reference_chart(db_path: Path) -> None:
@@ -30,8 +28,20 @@ def render_reference_chart(db_path: Path) -> None:
 
     Opens its own short-lived read-only connection (the standard per-view
     pattern), queries mean entity-ID F1 per strategy, and renders a bar chart
-    colored by the strategy palette. Shows an empty-state if no metrics exist.
+    colored by the strategy palette. Shows an empty-state if the database file
+    is missing or has no scored runs.
     """
+    # Guard the missing-file case first: a read-only (mode=ro) connect raises
+    # OperationalError on a nonexistent file, which would otherwise escape the
+    # empty-data check below.
+    if not viz_db.database_exists(db_path):
+        empty_state(
+            "Database not found.",
+            f"No database at `{db_path}`. Run an experiment first, or update "
+            "the path in ⚙️ Settings.",
+        )
+        return
+
     with viz_db.connect(db_path) as conn:
         data = viz_queries.mean_entity_id_f1_by_strategy(conn)
 
@@ -42,27 +52,31 @@ def render_reference_chart(db_path: Path) -> None:
         )
         return
 
-    strategies = [row[0] for row in data]
+    # DB stores enum values (e.g. "single_agent"); the chart shows the design
+    # guide's display names (e.g. "Single Agent"). Colors look up by the raw
+    # value (the mapping lives in theme.strategy_color).
+    values = [row[0] for row in data]
     scores = [row[1] for row in data]
-    colors = [strategy_color(s) for s in strategies]
+    names = [strategy_display_name(v) for v in values]
+    colors = [strategy_color(v) for v in values]
 
     fig, ax = new_figure()
     # Fixed bar width (in category units, max 1.0) keeps a single bar from
     # stretching edge-to-edge, and leaves even gaps once several strategies
     # are present.
-    bars = ax.bar(strategies, scores, color=colors, width=0.6)
+    bars = ax.bar(names, scores, color=colors, width=0.6)
     ax.set_ylabel("Entity-ID F1 (mean)")
     ax.set_ylim(0, 1)
     ax.set_xlabel("Strategy")
     # Pad the x-axis so a lone bar isn't flush against the spines.
-    ax.margins(x=0.3 if len(strategies) == 1 else 0.1)
+    ax.margins(x=0.3 if len(names) == 1 else 0.1)
 
     # Place the strategy name *inside* the bar (white, vertically centered)
     # when it's tall enough to hold the text, and drop the redundant x-axis
     # tick label in that case. For short bars the name can't fit inside, so
     # keep it on the axis below instead.
     keep_xtick = []
-    for bar, name in zip(bars, strategies):
+    for bar, name in zip(bars, names):
         x = bar.get_x() + bar.get_width() / 2
         if bar.get_height() >= 0.25:
             ax.text(
@@ -77,7 +91,7 @@ def render_reference_chart(db_path: Path) -> None:
             keep_xtick.append("")
         else:
             keep_xtick.append(name)
-    ax.set_xticks(range(len(strategies)))
+    ax.set_xticks(range(len(names)))
     ax.set_xticklabels(keep_xtick)
 
     fig.tight_layout()
@@ -86,9 +100,8 @@ def render_reference_chart(db_path: Path) -> None:
         fig,
         filename="entity_id_f1_by_strategy",
         key="reference-chart",
-        caption="Reference chart — mean entity-ID F1 per strategy.",
-    )
-
-    st.caption(
-        "This is the design-system reference chart: the template the data views follow."
+        caption=(
+            "Reference chart — mean entity-ID F1 per strategy. This is the "
+            "design-system template the data views follow."
+        ),
     )

--- a/src/maestro/viz/queries.py
+++ b/src/maestro/viz/queries.py
@@ -17,10 +17,17 @@ from __future__ import annotations
 import re
 import sqlite3
 
+from maestro.experiment_config import CONTROL_STRATEGIES
+
 # A valid SQLite identifier for our purposes: a bare table name. Used to
 # reject anything that isn't a plain identifier before it reaches an
 # interpolated query (table names can't be bound as parameters).
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# String values of the control strategies, for excluding them from
+# strategy-comparison queries (controls are reference floors/ceiling, not
+# orchestration strategies under test).
+_CONTROL_VALUES: tuple[str, ...] = tuple(s.value for s in CONTROL_STRATEGIES)
 
 
 def table_exists(conn: sqlite3.Connection, table: str) -> bool:
@@ -69,21 +76,27 @@ def mean_entity_id_f1_by_strategy(
     conn: sqlite3.Connection,
 ) -> list[tuple[str, float]]:
     """
-    Mean ``entity_id_f1`` per strategy across all scored runs, as
-    ``(strategy, mean_f1)`` pairs ordered by strategy name.
+    Mean ``entity_id_f1`` per orchestration strategy across all scored runs,
+    as ``(strategy, mean_f1)`` pairs ordered by strategy name.
 
-    Returns an empty list when there are no metric rows (callers show an
-    empty-state). Joins run_configs to metric_results on run_id.
+    Control strategies are excluded — they are reference floors/ceiling, not
+    orchestration strategies under test, and would otherwise show as gray bars
+    alongside the real strategies. Returns an empty list when there are no
+    metric rows (callers show an empty-state). Joins run_configs to
+    metric_results on run_id.
     """
     if not (table_exists(conn, "metric_results") and table_exists(conn, "run_configs")):
         return []
+    placeholders = ",".join("?" * len(_CONTROL_VALUES))
     rows = conn.execute(
-        """
+        f"""
         SELECT c.strategy AS strategy, AVG(m.entity_id_f1) AS mean_f1
         FROM run_configs c
         JOIN metric_results m ON c.run_id = m.run_id
+        WHERE c.strategy NOT IN ({placeholders})
         GROUP BY c.strategy
         ORDER BY c.strategy
-        """
+        """,
+        _CONTROL_VALUES,
     ).fetchall()
     return [(r["strategy"], float(r["mean_f1"])) for r in rows]

--- a/src/maestro/viz/queries.py
+++ b/src/maestro/viz/queries.py
@@ -63,3 +63,27 @@ def has_any_runs(conn: sqlite3.Connection) -> bool:
 def has_any_metrics(conn: sqlite3.Connection) -> bool:
     """True if at least one run has been scored (metric_results populated)."""
     return count_rows(conn, "metric_results") > 0
+
+
+def mean_entity_id_f1_by_strategy(
+    conn: sqlite3.Connection,
+) -> list[tuple[str, float]]:
+    """
+    Mean ``entity_id_f1`` per strategy across all scored runs, as
+    ``(strategy, mean_f1)`` pairs ordered by strategy name.
+
+    Returns an empty list when there are no metric rows (callers show an
+    empty-state). Joins run_configs to metric_results on run_id.
+    """
+    if not (table_exists(conn, "metric_results") and table_exists(conn, "run_configs")):
+        return []
+    rows = conn.execute(
+        """
+        SELECT c.strategy AS strategy, AVG(m.entity_id_f1) AS mean_f1
+        FROM run_configs c
+        JOIN metric_results m ON c.run_id = m.run_id
+        GROUP BY c.strategy
+        ORDER BY c.strategy
+        """
+    ).fetchall()
+    return [(r["strategy"], float(r["mean_f1"])) for r in rows]

--- a/src/maestro/viz/theme.py
+++ b/src/maestro/viz/theme.py
@@ -172,6 +172,15 @@ def strategy_color(strategy_value: str) -> str:
     return STRATEGY_COLORS[name]
 
 
+def strategy_display_name(strategy_value: str) -> str:
+    """
+    Human display name for a DB strategy value (e.g. ``"single_agent"`` →
+    ``"Single Agent"``), per the design guide. Falls back to the raw value for
+    anything unmapped (e.g. control strategies), so charts always have a label.
+    """
+    return _STRATEGY_VALUE_TO_NAME.get(strategy_value, strategy_value)
+
+
 def model_color(model_id: str) -> str:
     """
     Color for a model, given the id stored in ``run_configs.model`` (e.g.

--- a/src/maestro/viz/theme.py
+++ b/src/maestro/viz/theme.py
@@ -1,0 +1,196 @@
+"""
+MAESTRO viz — matplotlib theme and color palettes.
+
+Implements the project Visualization Design Guide
+(docs/visualization_design_guide.md). The palette dictionaries below are
+copied verbatim from that guide (keyed by human display name, as the guide
+specifies); the mapping helpers bridge from the values the database stores
+(enum strings like ``single_agent``, model ids like
+``claude-haiku-4-5-20251001``) to those display-keyed palettes.
+
+Three categorical dimensions each get their own visual signature — strategy
+(pink→magenta gradient), provider (one hue per provider, two lightness stops
+for smaller-model vs flagship), tier (amber gradient) — plus a shared
+sequential colormap for continuous metrics. The style itself (Arial, L-shaped
+dark-gray axes, light grid, white background) is applied via
+``apply_thesis_style``.
+"""
+
+from __future__ import annotations
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+# ---------------------------------------------------------------------------
+# Palettes — verbatim from the design guide (display-name keys).
+# ---------------------------------------------------------------------------
+
+# Provider gradients. Each list is [smaller model, flagship].
+PROVIDER_TIERS: dict[str, list[str]] = {
+    "Claude": ["#F0997B", "#993C1D"],
+    "ChatGPT": ["#6B7280", "#1F2937"],
+    "Mistral": ["#A78BFA", "#5B21B6"],
+    "Gemini": ["#60A5FA", "#1E40AF"],
+    "DeepSeek": ["#14B8A6", "#115E59"],
+}
+
+# Strategy gradient. Ordered light = least explicit orchestration (the
+# single-LLM-call baseline), dark = most explicit (the graph workflow). This
+# assignment is frozen — never reassign a strategy's color across charts.
+STRATEGY_COLORS: dict[str, str] = {
+    "Single Agent": "#ED93B1",
+    "SOP": "#D4537E",
+    "Crew AI": "#993556",
+    "LangGraph": "#72243E",
+}
+
+# Tier gradient. Light = simple input, dark = complex. Tier 3 is a reserved
+# slot for the optional expansion analysis.
+TIER_COLORS: dict[int, str] = {
+    1: "#FAC775",
+    2: "#BA7517",
+    3: "#633806",
+}
+
+# Continuous-metric colormap (heatmaps etc.). Use with explicit vmin/vmax and
+# a labelled colorbar.
+HEAT_COLORMAP: str = "YlOrRd"
+
+# Neutral gray for control conditions, which are reference floors/ceiling
+# rather than a dimension to color distinctly. (Not part of the guide's named
+# palettes; controls are excluded from most charts, and where they appear they
+# should read as subordinate.)
+CONTROL_COLOR: str = "#9CA3AF"
+
+# Default categorical cycle for a dimension without its own palette: the
+# strategy gradient, in its frozen order.
+DEFAULT_CYCLE: list[str] = list(STRATEGY_COLORS.values())
+
+# ---------------------------------------------------------------------------
+# DB-value → guide-display mappings.
+#
+# The database stores enum values and full model ids; the guide keys palettes
+# by display name. These dicts are the bridge. Keep them in sync with
+# maestro.schemas.Strategy and maestro.experiment_config.MODELS.
+# ---------------------------------------------------------------------------
+
+# Strategy enum value (run_configs.strategy) → guide display name.
+_STRATEGY_VALUE_TO_NAME: dict[str, str] = {
+    "single_agent": "Single Agent",
+    "sop_based": "SOP",
+    "crew_ai": "Crew AI",
+    "lang_graph": "LangGraph",
+}
+
+# Model id (run_configs.model) → (provider display name, slot) where slot is
+# 0 for the smaller/efficiency model and 1 for the flagship. All currently
+# configured models are the smaller (light) stop; flagships map to slot 1 when
+# added.
+_MODEL_TO_PROVIDER_SLOT: dict[str, tuple[str, int]] = {
+    "claude-haiku-4-5-20251001": ("Claude", 0),
+    "gpt-4o-mini-2024-07-18": ("ChatGPT", 0),
+    "mistral-small-2603": ("Mistral", 0),
+    "gemini-2.5-flash-lite": ("Gemini", 0),
+    "deepseek-v4-flash": ("DeepSeek", 0),
+}
+
+# Module-level guard so the rcParams update runs once per process even if
+# apply_thesis_style is called from several views in a single rerun.
+_STYLE_APPLIED = False
+
+
+def apply_thesis_style(*, force: bool = False) -> None:
+    """
+    Apply the house matplotlib style to ``plt.rcParams`` (idempotent).
+
+    Mirrors the typography / axes / gridline / background rules of the design
+    guide. Safe to call from every view; the work happens only on the first
+    call unless ``force=True`` (useful in tests that mutate rcParams).
+    """
+    global _STYLE_APPLIED
+    if _STYLE_APPLIED and not force:
+        return
+
+    plt.rcParams.update(
+        {
+            # Typography — Arial with cross-platform fallbacks.
+            "font.family": "sans-serif",
+            "font.sans-serif": ["Arial", "Liberation Sans", "DejaVu Sans"],
+            "font.size": 11,
+            "axes.labelsize": 10,
+            "axes.labelweight": "bold",
+            "xtick.labelsize": 9,
+            "ytick.labelsize": 9,
+            "legend.fontsize": 9,
+            # Axes — L-shape, dark-gray spines.
+            "axes.edgecolor": "#333333",
+            "axes.linewidth": 0.75,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            # Ticks — outside, major only.
+            "xtick.color": "#333333",
+            "ytick.color": "#333333",
+            "xtick.major.size": 3,
+            "ytick.major.size": 3,
+            "xtick.major.width": 0.75,
+            "ytick.major.width": 0.75,
+            "xtick.direction": "out",
+            "ytick.direction": "out",
+            # Gridlines — light, solid, behind the data.
+            "axes.grid": True,
+            "axes.axisbelow": True,
+            "grid.color": "#D0D0D0",
+            "grid.linewidth": 0.5,
+            "grid.linestyle": "-",
+            # Background — white everywhere (screen and saved files).
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+            "savefig.facecolor": "white",
+            # Default categorical color cycle (strategy gradient order).
+            "axes.prop_cycle": mpl.cycler(color=DEFAULT_CYCLE),
+        }
+    )
+    _STYLE_APPLIED = True
+
+
+# ---------------------------------------------------------------------------
+# Color lookups — accept the values stored in the database.
+# ---------------------------------------------------------------------------
+
+
+def strategy_color(strategy_value: str) -> str:
+    """
+    Color for a strategy, given the value stored in ``run_configs.strategy``
+    (e.g. ``"single_agent"``). Returns the frozen gradient color for the four
+    orchestration strategies, and the neutral control gray for control
+    conditions or any unmapped value (so a chart never crashes on a new
+    strategy before its mapping is added).
+    """
+    name = _STRATEGY_VALUE_TO_NAME.get(strategy_value)
+    if name is None:
+        return CONTROL_COLOR
+    return STRATEGY_COLORS[name]
+
+
+def model_color(model_id: str) -> str:
+    """
+    Color for a model, given the id stored in ``run_configs.model`` (e.g.
+    ``"claude-haiku-4-5-20251001"``). Resolves to the provider's hue at the
+    model's lightness slot (smaller vs flagship). Neutral gray if unmapped.
+    """
+    mapping = _MODEL_TO_PROVIDER_SLOT.get(model_id)
+    if mapping is None:
+        return CONTROL_COLOR
+    provider, slot = mapping
+    return PROVIDER_TIERS[provider][slot]
+
+
+def provider_of(model_id: str) -> str | None:
+    """Provider display name for a model id, or None if unmapped."""
+    mapping = _MODEL_TO_PROVIDER_SLOT.get(model_id)
+    return mapping[0] if mapping else None
+
+
+def tier_color(tier: int) -> str:
+    """Color for a tier integer (1/2/3). Neutral gray if out of range."""
+    return TIER_COLORS.get(tier, CONTROL_COLOR)

--- a/src/maestro/viz/views/__init__.py
+++ b/src/maestro/viz/views/__init__.py
@@ -19,6 +19,9 @@ from collections.abc import Callable
 
 import streamlit as st
 
+from maestro.viz import settings as viz_settings
+from maestro.viz.charts_reference import render_reference_chart
+
 # Names of the planned data views, shown in the nav as placeholders so the
 # eventual structure is visible before each is implemented.
 _PLANNED_VIEWS: tuple[str, ...] = (
@@ -31,13 +34,22 @@ _PLANNED_VIEWS: tuple[str, ...] = (
 
 
 def _render_placeholder() -> None:
-    """The Home view: confirms the app is wired up."""
+    """
+    The Home view: confirms the app is wired up and shows the design-system
+    reference chart against the configured database.
+    """
     st.title("MAESTRO — Results Dashboard")
     st.write(
         "Navigation, read-only database access, settings, and empty-state "
         "handling are in place. Select a planned view from the sidebar to see "
         "its placeholder."
     )
+    st.divider()
+    # Bound the chart to a left-hand portion of the wide page so the figure
+    # sits in a defined region instead of dictating the full-width layout.
+    chart_col, _ = st.columns([2, 1])
+    with chart_col:
+        render_reference_chart(viz_settings.current_settings().db_path)
 
 
 def _make_planned_placeholder(name: str) -> Callable[[], None]:

--- a/tests/viz/test_scaffold.py
+++ b/tests/viz/test_scaffold.py
@@ -15,6 +15,7 @@ a missing-streamlit environment into a clean skip.
 from __future__ import annotations
 
 import sqlite3
+import uuid
 
 import pytest
 
@@ -139,6 +140,69 @@ def test_has_any_runs_true_after_insert():
         "VALUES ('r1', 'single_agent', 'm', 'ex', 2, 1, '2026-01-01T00:00:00Z')"
     )
     assert viz_queries.has_any_runs(conn) is True
+
+
+def test_mean_f1_by_strategy_excludes_controls():
+    """Control strategies must not appear in the strategy-comparison query."""
+    conn = _mem_db(with_schema=True)
+
+    # The metric_results table has many NOT NULL numeric columns; build a row
+    # via a real MetricResult and persist it through the production insert so
+    # the test never drifts from the schema.
+    from maestro.db.queries import insert_metric_result
+    from maestro.schemas import MetricResult
+
+    def _insert(strategy, f1):
+        run_id = uuid.uuid4()
+        conn.execute(
+            "INSERT INTO run_configs "
+            "(run_id, strategy, model, example_id, tier, run_number, timestamp) "
+            "VALUES (?, ?, 'm', 'ex', 2, 1, '2026-01-01T00:00:00Z')",
+            (str(run_id), strategy),
+        )
+        insert_metric_result(
+            conn,
+            MetricResult(
+                run_id=run_id,
+                parses_valid=True,
+                entity_id_precision=f1,
+                entity_id_recall=f1,
+                entity_id_f1=f1,
+                entity_name_precision=0.0,
+                entity_name_recall=0.0,
+                entity_name_f1=0.0,
+                entity_lemma_precision=0.0,
+                entity_lemma_recall=0.0,
+                entity_lemma_f1=0.0,
+                relationship_relaxed_precision=0.0,
+                relationship_relaxed_recall=0.0,
+                relationship_relaxed_f1=0.0,
+                relationship_strict_precision=0.0,
+                relationship_strict_recall=0.0,
+                relationship_strict_f1=0.0,
+                entities_in_output=0,
+                entities_in_truth=0,
+                relationships_in_output=0,
+                relationships_in_truth=0,
+                missing_entities=0,
+                extra_entities=0,
+                false_entities=0,
+                duplicate_entities=0,
+                missing_relationships=0,
+                extra_relationships=0,
+                false_relationships=0,
+                duplicate_relationships=0,
+            ),
+        )
+
+    _insert("single_agent", 0.8)
+    _insert("null_control", 0.0)
+    _insert("ground_truth_control", 1.0)
+
+    result = dict(viz_queries.mean_entity_id_f1_by_strategy(conn))
+    assert "single_agent" in result
+    assert "null_control" not in result
+    assert "ground_truth_control" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/viz/test_theme.py
+++ b/tests/viz/test_theme.py
@@ -1,0 +1,142 @@
+"""
+Tests for the viz design system: theme palettes (per the Visualization Design
+Guide), the DB-value→color mappings, style application, and the chart export
+path.
+
+These run without a Streamlit server. The export path (savefig to PNG/SVG
+bytes) is the part of chart.py that matters for the thesis deliverable and is
+verifiable headless; the st.pyplot/download_button display is exercised by
+launching the app, not pytest.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("matplotlib")
+pytest.importorskip("streamlit")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")  # headless backend — no display needed for tests
+
+from maestro.experiment_config import CONTROL_STRATEGIES, MODELS  # noqa: E402
+from maestro.schemas import Strategy  # noqa: E402
+from maestro.viz import theme  # noqa: E402
+from maestro.viz.chart import _savefig_bytes, new_figure  # noqa: E402
+
+_HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+_LLM_STRATEGIES = [s.value for s in Strategy if s not in CONTROL_STRATEGIES]
+
+
+# ---------------------------------------------------------------------------
+# Palettes match the guide
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_palette_matches_guide():
+    """The frozen strategy gradient — display names and hexes verbatim."""
+    assert theme.STRATEGY_COLORS == {
+        "Single Agent": "#ED93B1",
+        "SOP": "#D4537E",
+        "Crew AI": "#993556",
+        "LangGraph": "#72243E",
+    }
+
+
+def test_provider_tiers_have_light_and_dark_stops():
+    for provider, stops in theme.PROVIDER_TIERS.items():
+        assert len(stops) == 2, f"{provider} needs [smaller, flagship]"
+        assert all(_HEX_RE.match(c) for c in stops)
+
+
+def test_tier_palette_keyed_by_int():
+    assert set(theme.TIER_COLORS) == {1, 2, 3}
+    assert all(_HEX_RE.match(c) for c in theme.TIER_COLORS.values())
+
+
+def test_heat_colormap_is_ylorrd():
+    assert theme.HEAT_COLORMAP == "YlOrRd"
+
+
+# ---------------------------------------------------------------------------
+# DB-value → color mappings cover the real entities
+# ---------------------------------------------------------------------------
+
+
+def test_every_llm_strategy_maps_to_a_gradient_color():
+    """Each non-control strategy value resolves to one of the frozen colors."""
+    for value in _LLM_STRATEGIES:
+        color = theme.strategy_color(value)
+        assert color in theme.STRATEGY_COLORS.values(), value
+
+
+def test_every_configured_model_maps_to_a_provider_color():
+    """Each real model id resolves to a color from its provider's gradient."""
+    for mp in MODELS:
+        if mp.model == "control":
+            continue
+        color = theme.model_color(mp.model)
+        provider = theme.provider_of(mp.model)
+        assert provider is not None, f"{mp.model} has no provider mapping"
+        assert color in theme.PROVIDER_TIERS[provider], mp.model
+
+
+def test_strategy_color_falls_back_for_controls_and_unknown():
+    assert theme.strategy_color("null_control") == theme.CONTROL_COLOR
+    assert theme.strategy_color("nonexistent") == theme.CONTROL_COLOR
+
+
+def test_model_color_falls_back_for_unknown():
+    assert theme.model_color("no-such-model") == theme.CONTROL_COLOR
+    assert theme.provider_of("no-such-model") is None
+
+
+def test_tier_color_lookup_and_fallback():
+    assert theme.tier_color(1) == theme.TIER_COLORS[1]
+    assert theme.tier_color(99) == theme.CONTROL_COLOR
+
+
+# ---------------------------------------------------------------------------
+# Style application
+# ---------------------------------------------------------------------------
+
+
+def test_apply_thesis_style_sets_rcparams():
+    import matplotlib.pyplot as plt
+
+    theme.apply_thesis_style(force=True)
+    assert plt.rcParams["axes.spines.top"] is False
+    assert plt.rcParams["axes.spines.right"] is False
+    assert plt.rcParams["font.family"] == ["sans-serif"]
+    assert "Arial" in plt.rcParams["font.sans-serif"]
+
+
+# ---------------------------------------------------------------------------
+# Export path — the thesis-figure deliverable
+# ---------------------------------------------------------------------------
+
+
+def test_export_produces_png_and_svg_bytes():
+    import matplotlib.pyplot as plt
+
+    fig, ax = new_figure()
+    ax.bar(["a", "b"], [0.5, 0.9])
+
+    png = _savefig_bytes(fig, "png")
+    svg = _savefig_bytes(fig, "svg")
+
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic number
+    assert b"<svg" in svg
+
+    plt.close(fig)
+
+
+def test_new_figure_applies_style():
+    import matplotlib.pyplot as plt
+
+    fig, ax = new_figure()
+    assert plt.rcParams["axes.spines.top"] is False
+    plt.close(fig)


### PR DESCRIPTION
Add docs/visualization_design_guide.md (the living spec) and implement its section 1–4 standards in the viz layer.

- theme.py: palettes copied verbatim from the guide — STRATEGY_COLORS (frozen pink→magenta gradient), PROVIDER_TIERS (one hue per provider × two lightness stops), TIER_COLORS (amber, keyed by int), HEAT_COLORMAP (YlOrRd). A mapping layer bridges the values the database stores (strategy enum values, model ids) to the guide's display-name-keyed palettes via strategy_color / model_color / tier_color / provider_of. apply_thesis_style applies the guide's typography / L-shaped axes / gridline / background rules.
- chart.py: new_figure() (themed fig, guide's tall-bar default size) and render_chart() (st.pyplot at container width + PNG/SVG download, figure closed after to avoid matplotlib's global leak).
- charts_reference.py: reference chart (mean entity-ID F1 per strategy, name labelled inside each bar) — the copy-paste template for the data views, wrapped in a bounded column so the figure doesn't dictate page width.
- queries.py: mean_entity_id_f1_by_strategy read for the reference chart.
- matplotlib added to core dependencies.
- tests/viz/test_theme.py: palettes match the guide, every real strategy/model maps to a palette color, fallbacks, style application, and the PNG/SVG export path.

---

based off #46 but I changed the approach as e-chart plugin to streamlit is currently unstable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home dashboard now displays strategy performance reference chart with color-coded results
  * Implemented chart rendering and export to PNG and SVG formats for all visualizations

* **Documentation**
  * Published comprehensive visualization design guide covering standard color palettes, typography, accessibility requirements (WCAG compliance), and chart formatting conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->