### PR TITLE
feat(docker): containerize the experiment runner + visualizer (#20, #21)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxrandr2 \
     && rm -rf /var/lib/apt/lists/*
 
+# Image digest for run provenance. An image cannot know its own digest at
+# build time, so it is passed in (e.g. the CI-resolved digest or the git SHA)
+# and baked as an env var; environment.capture_environment() reads it into
+# run_environments.docker_image_digest. Unset → recorded as NULL.
+ARG MAESTRO_IMAGE_DIGEST=
+ENV MAESTRO_IMAGE_DIGEST=$MAESTRO_IMAGE_DIGEST
+
 # mermaid-cli, pinned for reproducibility. Puppeteer must use the system
 # Chromium (installed above) rather than downloading its own — and Chromium
 # refuses to run as root without --no-sandbox, which is the norm in CI/Docker.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,74 @@
-# MAESTRO - Multi-Agent Evaluation for Structured Relational Output
-# Dockerfile for cross-platform reproducibility
+# MAESTRO — Multi-Agent Evaluation for Structured Relational Output
+# Dockerfile for cross-platform reproducibility.
+#
+# The image carries both halves of the pipeline:
+#   * Python 3.11 — runs the experiment (models, strategies, scoring, DB).
+#   * mermaid-cli (mmdc) + Chromium — backs the structural-validity metric
+#     (analysis/metrics.py shells out to `mmdc` to compute parses_valid; without
+#     it that metric is recorded as NULL for every run).
 
 FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies
+# System dependencies:
+#   * git              — environment.py records the commit hash per run
+#   * nodejs / npm     — runtime for mermaid-cli
+#   * chromium         — mmdc renders via Puppeteer, which needs a browser
+#   * the lib*/fonts*  — shared libraries Chromium needs to start headless
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    nodejs \
+    npm \
+    chromium \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy project files
+# mermaid-cli, pinned for reproducibility. Puppeteer must use the system
+# Chromium (installed above) rather than downloading its own — and Chromium
+# refuses to run as root without --no-sandbox, which is the norm in CI/Docker.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+RUN npm install -g @mermaid-js/mermaid-cli@11.4.2
+
+# A Puppeteer launch config so mmdc starts Chromium headless without a sandbox.
+# Chromium refuses to run as root without --no-sandbox; --disable-dev-shm-usage
+# avoids crashes from the small /dev/shm Docker allocates by default. mmdc only
+# honours these via a config file passed with `-p`, so metrics.py reads this
+# path from MERMAID_PUPPETEER_CONFIG and forwards it as `-p`.
+RUN printf '{"args":["--no-sandbox","--disable-gpu","--disable-dev-shm-usage"]}' \
+    > /app/puppeteer.json
+ENV MERMAID_PUPPETEER_CONFIG=/app/puppeteer.json
+
+# Python project. Copy metadata first so the dependency layer caches across
+# source-only changes.
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
-
-# Install Python dependencies
 RUN pip install --no-cache-dir -e .
 
-# Default command
+# Sanity: fail the build if mmdc can't actually render, so a broken
+# Chromium/Puppeteer setup is caught here, not 80% into a real run. Uses a temp
+# file (not /dev/stdin) so this checks the browser, not the input path; -p makes
+# the launch config explicit rather than relying on env discovery.
+RUN printf 'flowchart LR\n  a["A"] --> b["B"]\n' > /tmp/smoke.mmd \
+    && mmdc -p /app/puppeteer.json -i /tmp/smoke.mmd -o /tmp/smoke.png -e png \
+    && rm -f /tmp/smoke.mmd /tmp/smoke.png
+
+# Default: print the version. Override with the experiment runner, e.g.
+#   docker compose run --rm maestro python -m maestro.run --tier 1
 CMD ["python", "-c", "import maestro; print(f'MAESTRO v{maestro.__version__}')"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,37 @@
 services:
+  # One image, two uses:
+  #   * `docker compose up`        → serves the Streamlit dashboard (default),
+  #                                  reading the experiment DB read-write so a
+  #                                  future in-app run can write to it.
+  #   * `docker compose run --rm maestro python -m maestro.run --tier 1`
+  #                                → runs an experiment on the SAME image; the
+  #                                  command overrides the dashboard default.
+  # The DB lives on the host at ./out so external tools (Jupyter, sqlite, BI)
+  # can read it directly.
   maestro:
     build: .
     container_name: maestro
     env_file:
       - .env
     environment:
-      # Write the SQLite DB into the mounted output directory so results
-      # survive container teardown. See experiment_config.DB_PATH.
+      # SQLite DB in the mounted output dir so results survive teardown and are
+      # reachable from the host. Both the runner (experiment_config.DB_PATH) and
+      # the dashboard (viz/settings.py) read this same var.
       MAESTRO_DB_PATH: /app/out/maestro.db
+    ports:
+      - "8501:8501"
     volumes:
       # Scoped mounts (not the whole repo) so the image's installed package,
       # /app/puppeteer.json, and the globally-installed mmdc are not shadowed.
       - ./data:/app/data:ro      # benchmark inputs + ground truth (read-only)
-      - ./out:/app/out           # experiment DB output, persisted on the host
-    # Run the experiment runner; pass CLI filters after the service name, e.g.
-    #   docker compose run --rm maestro --tier 1 --dry-run
-    entrypoint: ["python", "-m", "maestro.run"]
+      - ./out:/app/out           # experiment DB, persisted + host-accessible
+    # Default command = the dashboard, so `docker compose up` just serves it.
+    # --server.address=0.0.0.0 lets the host browser reach the container;
+    # headless disables Streamlit's browser-open and first-run prompt.
+    command:
+      - streamlit
+      - run
+      - src/maestro/viz/app.py
+      - --server.address=0.0.0.0
+      - --server.port=8501
+      - --server.headless=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,17 @@ services:
   maestro:
     build: .
     container_name: maestro
-    volumes:
-      - .:/app
     env_file:
       - .env
-    # Override default command for interactive use
-    # command: python -m maestro
+    environment:
+      # Write the SQLite DB into the mounted output directory so results
+      # survive container teardown. See experiment_config.DB_PATH.
+      MAESTRO_DB_PATH: /app/out/maestro.db
+    volumes:
+      # Scoped mounts (not the whole repo) so the image's installed package,
+      # /app/puppeteer.json, and the globally-installed mmdc are not shadowed.
+      - ./data:/app/data:ro      # benchmark inputs + ground truth (read-only)
+      - ./out:/app/out           # experiment DB output, persisted on the host
+    # Run the experiment runner; pass CLI filters after the service name, e.g.
+    #   docker compose run --rm maestro --tier 1 --dry-run
+    entrypoint: ["python", "-m", "maestro.run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,14 @@ services:
   # The DB lives on the host at ./out so external tools (Jupyter, sqlite, BI)
   # can read it directly.
   maestro:
-    build: .
+    build:
+      context: .
+      args:
+        # Optional run-provenance stamp baked into the image, surfaced in
+        # run_environments.docker_image_digest. Pass at build time, e.g.
+        #   MAESTRO_IMAGE_DIGEST=$(git rev-parse HEAD) docker compose build
+        # Unset → recorded as NULL.
+        MAESTRO_IMAGE_DIGEST: ${MAESTRO_IMAGE_DIGEST:-}
     container_name: maestro
     env_file:
       - .env

--- a/src/maestro/analysis/metrics.py
+++ b/src/maestro/analysis/metrics.py
@@ -8,6 +8,7 @@ Evaluation dimensions:
   4. Error taxonomy counts
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -43,6 +44,16 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     if mmdc is None:
         return (None, "mmdc not found — validation skipped")
 
+    # mmdc renders via Puppeteer/Chromium. In a container running as root,
+    # Chromium refuses to start without --no-sandbox, which mmdc only picks up
+    # from a config file passed with -p (it does NOT read a PUPPETEER_* env).
+    # MERMAID_PUPPETEER_CONFIG points at that file when set (see the Docker
+    # image); locally it is unset and mmdc uses its working default.
+    puppeteer_args: list[str] = []
+    puppeteer_config = os.environ.get("MERMAID_PUPPETEER_CONFIG")
+    if puppeteer_config and Path(puppeteer_config).is_file():
+        puppeteer_args = ["-p", puppeteer_config]
+
     # NamedTemporaryFile with delete=True cleans up after the context exits.
     # The file is created so mmdc has somewhere to write; we never read it.
     # NOTE: Windows-incompatible — Windows holds the named-temp-file open
@@ -52,7 +63,16 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     try:
         with tempfile.NamedTemporaryFile(suffix=".png", delete=True) as out:
             result = subprocess.run(
-                [mmdc, "-i", "/dev/stdin", "-o", out.name, "-e", "png"],
+                [
+                    mmdc,
+                    *puppeteer_args,
+                    "-i",
+                    "/dev/stdin",
+                    "-o",
+                    out.name,
+                    "-e",
+                    "png",
+                ],
                 input=diagram_code,
                 capture_output=True,
                 text=True,

--- a/src/maestro/experiment_config.py
+++ b/src/maestro/experiment_config.py
@@ -8,6 +8,7 @@ To add a new model:   append to MODELS
 To enable a strategy: add to STRATEGIES (once implemented)
 """
 
+import os
 from pathlib import Path
 
 from maestro.schemas import InputFile, ModelPricing, Strategy, Tier
@@ -379,6 +380,9 @@ CONTROL_STRATEGIES: set[Strategy] = {
 # Number of repeated runs per (input, strategy, model) cell
 DEFAULT_REPEATS = 5
 
-# SQLite database path (project root)
+# SQLite database path. Defaults to maestro.db in the project root; override
+# with MAESTRO_DB_PATH so a containerized run can write the DB to a mounted
+# host volume (the project root holds the installed package and is not bind
+# mounted) without touching code.
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-DB_PATH = PROJECT_ROOT / "maestro.db"
+DB_PATH = Path(os.environ.get("MAESTRO_DB_PATH") or PROJECT_ROOT / "maestro.db")

--- a/src/maestro/viz/mermaid_render.py
+++ b/src/maestro/viz/mermaid_render.py
@@ -16,6 +16,7 @@ we cannot produce. Requires: ``npm install -g @mermaid-js/mermaid-cli``.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -42,13 +43,32 @@ def render_mermaid_svg(diagram_code: str, *, timeout: int = 15) -> str | None:
     if mmdc is None or not diagram_code or not diagram_code.strip():
         return None
 
+    # Forward a Puppeteer launch config when one is configured (mirrors
+    # metrics.check_mermaid_valid). In a container running as root, Chromium
+    # needs --no-sandbox, which mmdc only honours from a -p config file, not an
+    # env var. Locally MERMAID_PUPPETEER_CONFIG is unset and mmdc uses its
+    # default; without this, in-container renders would silently return None.
+    puppeteer_args: list[str] = []
+    puppeteer_config = os.environ.get("MERMAID_PUPPETEER_CONFIG")
+    if puppeteer_config and Path(puppeteer_config).is_file():
+        puppeteer_args = ["-p", puppeteer_config]
+
     try:
         with tempfile.TemporaryDirectory() as tmp:
             in_path = Path(tmp) / "in.mmd"
             out_path = Path(tmp) / "out.svg"
             in_path.write_text(diagram_code, encoding="utf-8")
             result = subprocess.run(
-                [mmdc, "-i", str(in_path), "-o", str(out_path), "-e", "svg"],
+                [
+                    mmdc,
+                    *puppeteer_args,
+                    "-i",
+                    str(in_path),
+                    "-o",
+                    str(out_path),
+                    "-e",
+                    "svg",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=timeout,


### PR DESCRIPTION
## Summary

Make MAESTRO fully reproducible in one Docker image — the reproducibility backbone for the v1.0.0 experimental run. One image runs both halves of the pipeline: the experiment runner (`docker compose run`) and the Streamlit dashboard (`docker compose up`). Closes #20 and #21.

The hard part was getting the structural-validity metric to work headless: `parses_valid` shells out to `mmdc` (mermaid-cli), which renders via Puppeteer/Chromium. Both are now installed and configured to launch as root in the container.

## Usage

Serve the dashboard (default) → http://localhost:8501

```
docker compose up
```

Run an experiment on the same image:

```
docker compose run --rm maestro python -m maestro.run --tier 1
```

The SQLite DB lives on the host at `./out/maestro.db`, so external tools (Jupyter, sqlite, BI) can read it directly.

## What changed

**Image (#20)**

- `Dockerfile` — adds Node + `@mermaid-js/mermaid-cli@11.4.2` + headless Chromium and its shared libraries. A build-time smoke test renders a diagram so a broken Chromium/Puppeteer setup fails the build, not a multi-hour run.
- `metrics.py` — passes `mmdc -p <config>` when `MERMAID_PUPPETEER_CONFIG` is set. Chromium refuses to run as root without `--no-sandbox`, which mmdc only honours from a `-p` config file (not an env var). Unset locally, so nothing changes on dev machines.
- `experiment_config.py` — `DB_PATH` now respects `MAESTRO_DB_PATH`, so the DB can write to a mounted host volume without code changes.

**Single-service compose (#21)**

- `docker-compose.yml` — one service, two uses: the default command serves the dashboard; the runner is the same image with an overriding command. Scoped mounts (`./data` read-only, `./out`) so the installed package, `puppeteer.json`, and the global mmdc aren't shadowed by a bind mount.
- `mermaid_render.py` — the dashboard's diagram renderer gets the same `-p` config fix; otherwise in-container renders silently fell back to showing source instead of diagrams.

## Design notes

- **One image, not two.** Runner and viz share `build: .`. The LLM stack (langgraph/crewai) is carried for the runner; the viz reusing it costs nothing extra (no second build, guaranteed dependency parity). Slimming the viz into a separate image would require splitting `pyproject.toml` into extras — deferred as polish, not correctness.
- **Latency is a one-time tax.** First build ~5 min (pulls Chromium); every build after is cached (~seconds), and `docker compose run` starts in ~2s. This also sets up a future in-process GUI cleanly — runner and viz are the same code in the same image, so a Streamlit "Run" button would call the run loop directly, with no Docker-in-Docker.

## Verification (end-to-end, in-container)

- `docker compose run ... --tier 1 --dry-run` builds the full 1029-cell matrix.
- A real cell (`bpmn_1_03`, deepseek) runs and writes to `./out/maestro.db`.
- `parses_valid` is actually computed in-container (mmdc + Chromium launch `--no-sandbox`) — confirmed a Mermaid parse verdict, not a Chromium launch failure.
- `docker compose up` serves the dashboard; the Diagram Visualizer renders both ground-truth and generated diagrams (not source fallback).
- Full test suite (216) passes; `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker image now supports structural-metric computation via Mermaid diagram rendering with Chromium integration.
  * Streamlit dashboard now runs by default in Docker containers.

* **Improvements**
  * Database persistence: experiment SQLite database now mounts to host filesystem for easier access and backup.
  * Enhanced Docker setup with Node.js and system-level dependencies for improved reproducibility and cross-platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->