### PR TITLE
fix(metrics): make check_mermaid_valid cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Comparing agentic orchestration frameworks for automated relational diagram gene
 
 The benchmark runs a matrix of `inputs × strategies × models × repeats`, scores
 each generated Mermaid diagram against its ground truth, and records every
-result — plus the runtime environment — in a SQLite database. The steps below
+result (plus the runtime environment) in a SQLite database. The steps below
 run the experiment from a clean checkout.
 
 > This is a high-level walkthrough. A detailed guide (troubleshooting, full CLI
@@ -21,7 +21,7 @@ run the experiment from a clean checkout.
 ### Prerequisites
 
 - Python 3.11
-- API keys for the providers you intend to run —
+- API keys for the providers you intend to run:
   [Anthropic](https://docs.anthropic.com/en/api/overview),
   [OpenAI](https://platform.openai.com/docs/api-reference/authentication),
   [Mistral](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key),
@@ -29,13 +29,13 @@ run the experiment from a clean checkout.
   [DeepSeek](https://api-docs.deepseek.com/) (see each provider's docs for
   obtaining a key)
 - [`mmdc`](https://github.com/mermaid-js/mermaid-cli) (mermaid-cli) for the
-  structural-validity metric — optional locally (the metric is skipped if it is
+  structural-validity metric (optional locally; the metric is skipped if it is
   absent), bundled in the Docker image
-- Docker (optional) — only if you prefer the container path over a local install
+- Docker (optional), only if you prefer the container path over a local install
 
 The local install path is tested on macOS and works on Windows. The Docker path
 runs Linux inside the container, so it is platform-independent and is the
-recommended route on Windows — it bundles a headless Chromium, which the
+recommended route on Windows: it bundles a headless Chromium, which the
 `parses_valid` structural-validity metric needs. A native Windows install
 computes that metric only if mermaid-cli and a Puppeteer Chrome build
 (`npx puppeteer browsers install chrome`) are present; without them the metric
@@ -61,7 +61,7 @@ Copy the template and fill in the keys for the providers you will use:
 
 ```bash
 cp .env.template .env
-# edit .env — keys are read from the environment at run time
+# edit .env (keys are read from the environment at run time)
 ```
 
 ### 3. Validate the setup with a small run
@@ -100,8 +100,8 @@ docker compose up          # → http://localhost:8501
 
 ### Reproducibility audit trail
 
-Every invocation snapshots its runtime environment — OS, architecture, Python
-version, library versions, git commit, and (under Docker) the image digest —
+Every invocation snapshots its runtime environment (OS, architecture, Python
+version, library versions, git commit, and under Docker the image digest)
 into the `run_environments` table, linked to each run. This lets a later
 replication attempt diagnose diverging numbers against the exact stack that
 produced the original data.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ run the experiment from a clean checkout.
   absent), bundled in the Docker image
 - Docker (optional) — only if you prefer the container path over a local install
 
-The local install path is tested on macOS. The Docker path runs Linux inside
-the container, so it is platform-independent and is the recommended route on
-Windows.
+The local install path is tested on macOS and works on Windows. The Docker path
+runs Linux inside the container, so it is platform-independent and is the
+recommended route on Windows — it bundles a headless Chromium, which the
+`parses_valid` structural-validity metric needs. A native Windows install
+computes that metric only if mermaid-cli and a Puppeteer Chrome build
+(`npx puppeteer browsers install chrome`) are present; without them the metric
+is skipped, and the rest of the pipeline is unaffected.
 
 ### 1. Clone and install
 

--- a/src/maestro/analysis/metrics.py
+++ b/src/maestro/analysis/metrics.py
@@ -39,6 +39,13 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     current SDK rejects it with "Output file must end with…". We hand
     it a real temp PNG path, throw the file away, and only inspect the
     return code — the validity signal we actually want.
+
+    Both the input and output use explicit temp files from ``mkstemp`` so the
+    function is cross-platform: ``/dev/stdin`` does not exist on Windows, and
+    ``NamedTemporaryFile`` holds an exclusive lock there that would block mmdc
+    from writing the output. The descriptors are closed immediately (mmdc
+    opens the paths itself), the diagram is written via ``Path.write_text``,
+    and both files are removed in a ``finally`` block.
     """
     mmdc = shutil.which("mmdc")
     if mmdc is None:
@@ -54,33 +61,21 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     if puppeteer_config and Path(puppeteer_config).is_file():
         puppeteer_args = ["-p", puppeteer_config]
 
-    # NamedTemporaryFile with delete=True cleans up after the context exits.
-    # The file is created so mmdc has somewhere to write; we never read it.
-    # NOTE: Windows-incompatible — Windows holds the named-temp-file open
-    # exclusively, which would block mmdc from writing to it. The project
-    # targets macOS / Linux (Ubuntu CI), so this is a deliberate trade-off.
-    # ``/dev/stdin`` for the input side is also Unix-only by the same logic.
+    # mkstemp creates each file and returns (fd, path). Close the fds at once —
+    # we write the input via Path.write_text and mmdc opens both paths itself —
+    # which sidesteps Windows' exclusive-lock-on-open-handle behaviour.
+    in_fd, in_path = tempfile.mkstemp(suffix=".mmd")
+    out_fd, out_path = tempfile.mkstemp(suffix=".png")
+    os.close(in_fd)
+    os.close(out_fd)
     try:
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=True) as out:
-            result = subprocess.run(
-                [
-                    mmdc,
-                    *puppeteer_args,
-                    "-i",
-                    "/dev/stdin",
-                    "-o",
-                    out.name,
-                    "-e",
-                    "png",
-                ],
-                input=diagram_code,
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-        # ``result`` is bound inside the ``with`` block but Python's scoping
-        # makes it visible here; the temp file is gone by this point, which
-        # is fine because we only need the return code + stderr text.
+        Path(in_path).write_text(diagram_code, encoding="utf-8")
+        result = subprocess.run(
+            [mmdc, *puppeteer_args, "-i", in_path, "-o", out_path, "-e", "png"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
         if result.returncode == 0:
             return (True, None)
         return (False, result.stderr.strip()[:500])
@@ -88,6 +83,13 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
         return (False, "mmdc timed out after 15s")
     except Exception as e:
         return (False, str(e)[:500])
+    finally:
+        # Best-effort cleanup; teardown errors must not mask the result.
+        for p in (in_path, out_path):
+            try:
+                Path(p).unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/src/maestro/analysis/metrics.py
+++ b/src/maestro/analysis/metrics.py
@@ -61,14 +61,18 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     if puppeteer_config and Path(puppeteer_config).is_file():
         puppeteer_args = ["-p", puppeteer_config]
 
-    # mkstemp creates each file and returns (fd, path). Close the fds at once —
-    # we write the input via Path.write_text and mmdc opens both paths itself —
-    # which sidesteps Windows' exclusive-lock-on-open-handle behaviour.
-    in_fd, in_path = tempfile.mkstemp(suffix=".mmd")
-    out_fd, out_path = tempfile.mkstemp(suffix=".png")
-    os.close(in_fd)
-    os.close(out_fd)
+    # Initialised before the try so the finally cleanup is safe even if the
+    # mkstemp calls below raise (e.g. no temp dir / disk full).
+    in_path: str | None = None
+    out_path: str | None = None
     try:
+        # mkstemp creates each file and returns (fd, path). Close the fds at
+        # once — we write the input via Path.write_text and mmdc opens both
+        # paths itself — which sidesteps Windows' exclusive-lock behaviour.
+        in_fd, in_path = tempfile.mkstemp(suffix=".mmd")
+        out_fd, out_path = tempfile.mkstemp(suffix=".png")
+        os.close(in_fd)
+        os.close(out_fd)
         Path(in_path).write_text(diagram_code, encoding="utf-8")
         result = subprocess.run(
             [mmdc, *puppeteer_args, "-i", in_path, "-o", out_path, "-e", "png"],
@@ -84,8 +88,11 @@ def check_mermaid_valid(diagram_code: str) -> tuple[bool | None, str | None]:
     except Exception as e:
         return (False, str(e)[:500])
     finally:
-        # Best-effort cleanup; teardown errors must not mask the result.
+        # Best-effort cleanup; teardown errors must not mask the result. Paths
+        # may be None if mkstemp itself failed.
         for p in (in_path, out_path):
+            if p is None:
+                continue
             try:
                 Path(p).unlink(missing_ok=True)
             except OSError:

--- a/tests/analysis/test_metrics.py
+++ b/tests/analysis/test_metrics.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 
 import pytest
 
-from maestro.analysis.metrics import evaluate_run
+from maestro.analysis.metrics import check_mermaid_valid, evaluate_run
 from maestro.experiment_config import INPUTS
 
 # All tests run against the first registered input. If/when the input
@@ -104,6 +104,37 @@ def test_ground_truth_echo_scores_perfect_ceiling():
     assert metric.entity_lemma_f1 == 1.0
     assert metric.relationship_relaxed_f1 == 1.0
     assert metric.relationship_strict_f1 == 1.0
+
+
+def test_check_mermaid_valid_accepts_valid_diagram():
+    """
+    A syntactically valid diagram must validate (True). Skipped when mmdc is
+    not installed — the validator returns (None, skip_message) and there is
+    nothing to assert about validity.
+    """
+    is_valid, error = check_mermaid_valid('flowchart LR\n    a["A"] --> b["B"]')
+    if is_valid is None:
+        pytest.skip(f"mmdc not available: {error}")
+    assert is_valid is True
+    assert error is None
+
+
+def test_check_mermaid_valid_rejects_invalid_diagram():
+    """
+    The negative path through check_mermaid_valid: syntactically broken Mermaid
+    must score parses_valid=False with a non-empty parse error (mmdc's stderr).
+    Skipped when mmdc is not installed (validity is unknowable without it).
+
+    Exercises the cross-platform temp-file path end to end — the input is
+    written to a real temp file and mmdc renders to another, with no
+    ``/dev/stdin`` / ``/dev/null`` involved.
+    """
+    # Spaces inside the edge-label pipes are rejected by mmdc's parser.
+    is_valid, error = check_mermaid_valid('flowchart LR\n    a -->| "x" | b')
+    if is_valid is None:
+        pytest.skip(f"mmdc not available: {error}")
+    assert is_valid is False
+    assert error and error.strip()
 
 
 def test_empty_output_does_not_raise_on_zero_denominator():


### PR DESCRIPTION
## Summary

`check_mermaid_valid` used Unix-only paths (`/dev/stdin` input, auto-deleted `NamedTemporaryFile` output), so `parses_valid` failed on Windows. Replace both with explicit `mkstemp` temp files cleaned up in a `finally` block. Closes #44.

## Changes

- `metrics.py`: cross-platform temp files for mmdc input/output; drop the `Windows-incompatible` NOTE. The container `-p` puppeteer-config forwarding is preserved.
- `test_metrics.py`: add happy- and failure-path tests for `check_mermaid_valid` (both skip when mmdc is unavailable).
- `README.md`: note that Windows validity needs Docker (bundled Chromium) or a native Puppeteer Chrome install; metric is skipped otherwise.

## Verification

- Linux/macOS: full suite green (218 tests), ruff clean.
- Windows (native pytest): the fix reaches mmdc's render step instead of failing on `/dev/stdin` — confirming the path fix. Full native validity additionally needs a Puppeteer Chrome build.
- Windows (Docker): build, a real experiment cell, `parses_valid` computing in-container, and the dashboard rendering diagrams all verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup guidance with clearer API key prerequisites and enhanced platform-specific instructions for the optional Mermaid structural-validity metric, including Windows considerations and Docker recommendations.

* **Bug Fixes**
  * Improved reliability of Mermaid diagram validation with better error handling and cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->