### PR TITLE
chore: final model matrix + provider API fixes for current models (#50)

### DIFF
--- a/src/maestro/experiment_config.py
+++ b/src/maestro/experiment_config.py
@@ -289,56 +289,80 @@ CONTROL_MODEL = ModelPricing(
     output_price_per_1m=0.0,
 )
 
+# Two models per provider: a frontier ("best") model and an efficiency model,
+# so the experiment can compare quality against cost within and across vendors.
+# Prices are USD per 1M tokens, verified against each provider's pricing page in
+# April 2026 for the frozen main run. IDs are pinned to dated snapshots where
+# the provider offers one, so the run stays reproducible.
+#
+# Note: provider dispatch (run.py) is by substring (claude / gpt / mistral /
+# gemini / deepseek), so any new model id must contain its provider's needle.
+# tests/providers/test_provider_dispatch.py enforces this for every entry here.
 MODELS: list[ModelPricing] = [
+    # Anthropic
     ModelPricing(
-        model="claude-haiku-4-5-20251001",
-        input_price_per_1m=0.80,
-        output_price_per_1m=4.00,
+        model="claude-opus-4-8",  # frontier
+        input_price_per_1m=5.00,
+        output_price_per_1m=25.00,
+        # Opus 4.7+ removed sampling params; sending temperature returns 400.
+        supports_temperature=False,
     ),
     ModelPricing(
-        # Pinned to snapshot for reproducibility
-        model="gpt-4o-mini-2024-07-18",
+        model="claude-haiku-4-5-20251001",  # efficiency
+        input_price_per_1m=1.00,
+        output_price_per_1m=5.00,
+    ),
+    # OpenAI (GPT-5 family: max_completion_tokens, no custom temperature)
+    ModelPricing(
+        model="gpt-5.5-2026-04-23",  # frontier
+        input_price_per_1m=5.00,
+        output_price_per_1m=30.00,
+        supports_temperature=False,
+    ),
+    ModelPricing(
+        model="gpt-5.4-mini-2026-03-17",  # efficiency
+        input_price_per_1m=0.75,
+        output_price_per_1m=4.50,
+        supports_temperature=False,
+    ),
+    # Mistral
+    ModelPricing(
+        model="mistral-medium-3-5",  # frontier
+        input_price_per_1m=1.50,
+        output_price_per_1m=7.50,
+    ),
+    ModelPricing(
+        model="mistral-small-2603",  # efficiency
         input_price_per_1m=0.15,
         output_price_per_1m=0.60,
     ),
+    # Gemini
     ModelPricing(
-        model="mistral-small-2603",
-        input_price_per_1m=0.15,
-        output_price_per_1m=0.60,
+        model="gemini-3.5-flash",  # frontier
+        input_price_per_1m=1.50,
+        output_price_per_1m=9.00,
     ),
     ModelPricing(
-        model="gemini-2.5-flash-lite",
-        input_price_per_1m=0.10,
-        output_price_per_1m=0.40,
+        model="gemini-3.1-flash-lite",  # efficiency
+        input_price_per_1m=0.25,
+        output_price_per_1m=1.50,
     ),
-    # DeepSeek — the cross-provider replication dimension's emerging-Chinese
-    # entry (proposal §3.2). Consumed via the OpenAI-compatible endpoint
-    # (see providers/deepseek.py). Efficiency-tier model only for now; the
-    # edge model (deepseek-v4-pro) can be added later.
-    #
-    # Model id: "deepseek-v4-flash" is the CURRENT model as confirmed against
-    # the DeepSeek API docs (https://api-docs.deepseek.com/) on 2026-06-01.
-    # The older "deepseek-chat"/"deepseek-reasoner" aliases are the *legacy*
-    # names slated for deprecation on 2026-07-24 — deliberately avoided here so
-    # the pinned id outlives the frozen main run.
-    #
-    # Pricing is the *cache-miss* (standard) rate as of 2026-06-01
-    # (https://api-docs.deepseek.com/quick_start/pricing): DeepSeek also offers
-    # a ~10x-cheaper cache-hit input price, but ModelPricing has a single input
-    # rate, so we use cache-miss — every call is costed as a miss, making the
-    # tracked cost an upper bound on actual spend (never an under-count).
-    # Verify both id and price against the live console before the frozen run.
+    # DeepSeek: the cross-provider replication dimension's emerging-Chinese
+    # entry (proposal section 3.2), consumed via the OpenAI-compatible endpoint
+    # (see providers/deepseek.py). Pricing is the cache-MISS (standard) rate;
+    # DeepSeek also offers a cheaper cache-hit input price, but ModelPricing has
+    # a single input rate, so cache-miss makes the tracked cost an upper bound
+    # on actual spend (never an under-count).
     ModelPricing(
-        model="deepseek-v4-flash",
+        model="deepseek-v4-pro",  # frontier
+        input_price_per_1m=0.435,
+        output_price_per_1m=0.87,
+    ),
+    ModelPricing(
+        model="deepseek-v4-flash",  # efficiency
         input_price_per_1m=0.14,
         output_price_per_1m=0.28,
     ),
-    # --- Add new models below ---
-    # ModelPricing(
-    #     model="claude-sonnet-4-20250514",
-    #     input_price_per_1m=3.00,
-    #     output_price_per_1m=15.00,
-    # ),
 ]
 
 
@@ -380,9 +404,12 @@ CONTROL_STRATEGIES: set[Strategy] = {
 # Number of repeated runs per (input, strategy, model) cell
 DEFAULT_REPEATS = 5
 
-# SQLite database path. Defaults to maestro.db in the project root; override
-# with MAESTRO_DB_PATH so a containerized run can write the DB to a mounted
-# host volume (the project root holds the installed package and is not bind
-# mounted) without touching code.
+# SQLite database path. One canonical location, out/maestro.db, used by every
+# consumer: the local runner, the Docker runner, and the visualizer all resolve
+# here by default, so results land in one place regardless of how the run was
+# launched. out/ is the host-accessible experiment-output directory (the
+# project root holds the installed package). MAESTRO_DB_PATH overrides it; the
+# Docker compose still sets it explicitly so the path matches the mount.
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-DB_PATH = Path(os.environ.get("MAESTRO_DB_PATH") or PROJECT_ROOT / "maestro.db")
+DEFAULT_DB_PATH = PROJECT_ROOT / "out" / "maestro.db"
+DB_PATH = Path(os.environ.get("MAESTRO_DB_PATH") or DEFAULT_DB_PATH)

--- a/src/maestro/providers/anthropic.py
+++ b/src/maestro/providers/anthropic.py
@@ -24,7 +24,7 @@ _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 class AnthropicProvider(LLMProvider):
     """
-    Concrete provider for Anthropic models (claude-sonnet-4-5, etc.)
+    Concrete provider for Anthropic models (claude-opus-4-8, claude-haiku-4-5, etc.)
     Uses the official anthropic SDK — add 'anthropic>=0.25.0' to pyproject.toml.
     """
 
@@ -73,15 +73,17 @@ class AnthropicProvider(LLMProvider):
 
         def _do_call():
             """The SDK call ``call_with_retry`` re-runs on transient failures."""
-            return self._client.messages.create(
-                model=config.model,
-                max_tokens=self.MAX_TOKENS,
-                temperature=self.TEMPERATURE,
-                system=effective_system,
-                messages=[
-                    {"role": "user", "content": prompt},
-                ],
-            )
+            # Omit temperature for models that removed sampling params (Opus
+            # 4.7+/Fable return 400 if it is sent); see ModelPricing.
+            params = {
+                "model": config.model,
+                "max_tokens": self.MAX_TOKENS,
+                "system": effective_system,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+            if self.pricing.supports_temperature:
+                params["temperature"] = self.TEMPERATURE
+            return self._client.messages.create(**params)
 
         try:
             response, _ = call_with_retry(

--- a/src/maestro/providers/deepseek.py
+++ b/src/maestro/providers/deepseek.py
@@ -45,6 +45,10 @@ class DeepSeekProvider(OpenAIProvider):
     # Override so retry log lines read "deepseek", not the inherited "openai".
     _PROVIDER_NAME = "deepseek"
 
+    # DeepSeek's OpenAI-compatible endpoint uses the original max_tokens param,
+    # not OpenAI's GPT-5 max_completion_tokens. Override the inherited default.
+    _MAX_TOKENS_PARAM = "max_tokens"
+
     def __init__(self, api_key: str, pricing: ModelPricing) -> None:
         # Call LLMProvider.__init__ *explicitly* (not super(OpenAIProvider, ...))
         # to store api_key + pricing without running OpenAIProvider.__init__,

--- a/src/maestro/providers/gemini.py
+++ b/src/maestro/providers/gemini.py
@@ -20,8 +20,8 @@ _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 class GeminiProvider(LLMProvider):
     """
-    Concrete provider for Google Gemini models (gemini-2.5-flash, gemini-3.x, etc.)
-    Uses the official google-genai SDK — add 'google-genai>=1.0' to pyproject.toml.
+    Concrete provider for Google Gemini models (gemini-3.5-flash, etc.)
+    Uses the official google-genai SDK; add 'google-genai>=1.0' to pyproject.toml.
     """
 
     # SYSTEM_PROMPT inherited from LLMProvider (maestro.prompts).

--- a/src/maestro/providers/openai.py
+++ b/src/maestro/providers/openai.py
@@ -26,8 +26,8 @@ _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 class OpenAIProvider(LLMProvider):
     """
-    Concrete provider for OpenAI models (gpt-4o, gpt-4o-mini, etc.)
-    Uses the official openai SDK — add 'openai>=1.0.0' to pyproject.toml.
+    Concrete provider for OpenAI models (gpt-5.5, gpt-5.4-mini, etc.)
+    Uses the official openai SDK; add 'openai>=1.0.0' to pyproject.toml.
     """
 
     # Name used in retry log lines. Defined as a class attribute (rather than
@@ -40,6 +40,11 @@ class OpenAIProvider(LLMProvider):
 
     # Max tokens for the completion
     MAX_TOKENS = 4096
+
+    # The request parameter that caps output length. OpenAI's GPT-5 family
+    # renamed max_tokens -> max_completion_tokens; OpenAI-compatible endpoints
+    # that still expect the old name (e.g. DeepSeek) override this.
+    _MAX_TOKENS_PARAM = "max_completion_tokens"
 
     def __init__(self, api_key: str, pricing: ModelPricing) -> None:
         super().__init__(api_key, pricing)
@@ -88,15 +93,22 @@ class OpenAIProvider(LLMProvider):
 
         def _do_call():
             """The SDK call ``call_with_retry`` re-runs on transient failures."""
-            return self._client.chat.completions.create(
-                model=config.model,
-                max_tokens=self.MAX_TOKENS,
-                temperature=self.TEMPERATURE,
-                messages=[
+            # GPT-5 models renamed max_tokens -> max_completion_tokens and, like
+            # other reasoning models, reject a custom temperature. The token
+            # param name is _MAX_TOKENS_PARAM (subclasses on older endpoints
+            # override it); temperature is omitted for models that don't support
+            # it (see ModelPricing.supports_temperature).
+            params = {
+                "model": config.model,
+                self._MAX_TOKENS_PARAM: self.MAX_TOKENS,
+                "messages": [
                     {"role": "system", "content": effective_system},
                     {"role": "user", "content": prompt},
                 ],
-            )
+            }
+            if self.pricing.supports_temperature:
+                params["temperature"] = self.TEMPERATURE
+            return self._client.chat.completions.create(**params)
 
         try:
             response, _ = call_with_retry(

--- a/src/maestro/run.py
+++ b/src/maestro/run.py
@@ -248,7 +248,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Run only these models (default: all registered). "
             "Comma-separated for several, e.g. "
-            "--model gpt-4o-mini-2024-07-18,deepseek-v4-flash"
+            "--model gpt-5.4-mini-2026-03-17,deepseek-v4-flash"
         ),
     )
     parser.add_argument(
@@ -357,8 +357,8 @@ def build_matrix(args: argparse.Namespace) -> list[dict]:
     if strategy_names:
         strategies = [s for s in strategies if s.value in strategy_names]
 
-    # Filter models — applies only to real (LLM) strategies. Control rows
-    # ignore --model because they don't use a model; --model gpt-4o-mini
+    # Filter models, applies only to real (LLM) strategies. Control rows
+    # ignore --model because they don't use a model; a --model filter
     # should narrow which LLM rows run but should not silently drop the
     # sanity floor/ceiling rows the experiment needs.
     models = MODELS
@@ -366,8 +366,8 @@ def build_matrix(args: argparse.Namespace) -> list[dict]:
         models = [m for m in models if m.model in model_names]
 
     # Partition by strategy kind. Controls are deterministic in (model,
-    # repeat) — collapsing both dimensions to a single row per
-    # (input, control) avoids 40× duplicate rows per input that would
+    # repeat), so collapsing both dimensions to a single row per
+    # (input, control) avoids 40x duplicate rows per input that would
     # need to be filtered out at analysis time anyway.
     real_strategies = [s for s in strategies if s not in CONTROL_STRATEGIES]
     control_strategies = [s for s in strategies if s in CONTROL_STRATEGIES]
@@ -376,8 +376,8 @@ def build_matrix(args: argparse.Namespace) -> list[dict]:
     # strategy is selected. `--strategy null_control --model typo` stays a
     # no-op on --model (controls don't use any model), so it must not abort.
     # When a real strategy IS selected, a misspelled model would otherwise
-    # silently shrink the matrix (e.g. `--model gpt-4o-mini-2024-07-18,typo`
-    # would quietly run only the valid one) — so reject the typo loudly.
+    # silently shrink the matrix (e.g. `--model gpt-5.4-mini-2026-03-17,typo`
+    # would quietly run only the valid one), so reject the typo loudly.
     if model_names and real_strategies:
         registered = {m.model for m in MODELS}
         unknown = [m for m in model_names if m not in registered]

--- a/src/maestro/schemas.py
+++ b/src/maestro/schemas.py
@@ -152,6 +152,11 @@ class ModelPricing(BaseModel):
     model: str
     input_price_per_1m: float  # USD per 1M prompt tokens
     output_price_per_1m: float  # USD per 1M completion tokens
+    # Whether the model's API accepts a temperature parameter. Newer frontier
+    # models (e.g. Claude Opus 4.7+/Fable) removed sampling parameters and 400
+    # if temperature is sent; providers omit it when this is False. Defaults to
+    # True since most models still accept it.
+    supports_temperature: bool = True
 
 
 # ---------------------------------------------------------------------------

--- a/src/maestro/viz/theme.py
+++ b/src/maestro/viz/theme.py
@@ -83,14 +83,18 @@ _STRATEGY_VALUE_TO_NAME: dict[str, str] = {
 }
 
 # Model id (run_configs.model) → (provider display name, slot) where slot is
-# 0 for the smaller/efficiency model and 1 for the flagship. All currently
-# configured models are the smaller (light) stop; flagships map to slot 1 when
-# added.
+# 0 for the efficiency model and 1 for the frontier model. Keep this in sync
+# with experiment_config.MODELS (two ids per provider).
 _MODEL_TO_PROVIDER_SLOT: dict[str, tuple[str, int]] = {
+    "claude-opus-4-8": ("Claude", 1),
     "claude-haiku-4-5-20251001": ("Claude", 0),
-    "gpt-4o-mini-2024-07-18": ("ChatGPT", 0),
+    "gpt-5.5-2026-04-23": ("ChatGPT", 1),
+    "gpt-5.4-mini-2026-03-17": ("ChatGPT", 0),
+    "mistral-medium-3-5": ("Mistral", 1),
     "mistral-small-2603": ("Mistral", 0),
-    "gemini-2.5-flash-lite": ("Gemini", 0),
+    "gemini-3.5-flash": ("Gemini", 1),
+    "gemini-3.1-flash-lite": ("Gemini", 0),
+    "deepseek-v4-pro": ("DeepSeek", 1),
     "deepseek-v4-flash": ("DeepSeek", 0),
 }
 

--- a/tests/providers/test_anthropic_params.py
+++ b/tests/providers/test_anthropic_params.py
@@ -1,0 +1,67 @@
+"""
+Request-parameter tests for AnthropicProvider.
+
+Newer Anthropic models (Opus 4.7+/Fable) removed sampling parameters and return
+400 if `temperature` is sent; older ones (Haiku 4.5) still accept it. The
+provider decides per model via ModelPricing.supports_temperature. These tests
+pin that the temperature kwarg is omitted/included accordingly, without making
+a network call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from maestro.providers.anthropic import AnthropicProvider  # noqa: E402
+from maestro.schemas import ModelPricing, RunConfig, Strategy, Tier  # noqa: E402
+
+
+def _capture_create_kwargs(pricing: ModelPricing) -> dict:
+    """Run complete() with a stubbed SDK client and return the create() kwargs."""
+    captured: dict = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        usage = SimpleNamespace(input_tokens=1, output_tokens=1)
+        block = SimpleNamespace(text="graph TD\n a")
+        return SimpleNamespace(usage=usage, content=[block])
+
+    provider = AnthropicProvider(api_key="k", pricing=pricing)
+    provider._client = SimpleNamespace(messages=SimpleNamespace(create=fake_create))
+    cfg = RunConfig(
+        strategy=Strategy.SINGLE_AGENT,
+        model=pricing.model,
+        example_id="e",
+        tier=Tier.SIMPLE,
+        run_number=1,
+    )
+    provider.complete("x", cfg)
+    return captured
+
+
+def test_omits_temperature_when_unsupported():
+    """Opus 4.7+/Fable reject temperature — it must not be sent."""
+    pricing = ModelPricing(
+        model="claude-opus-4-8",
+        input_price_per_1m=5.0,
+        output_price_per_1m=25.0,
+        supports_temperature=False,
+    )
+    kwargs = _capture_create_kwargs(pricing)
+    assert "temperature" not in kwargs
+    assert kwargs["max_tokens"] == AnthropicProvider.MAX_TOKENS
+
+
+def test_includes_temperature_when_supported():
+    """Haiku 4.5 still accepts temperature — it must be sent."""
+    pricing = ModelPricing(
+        model="claude-haiku-4-5-20251001",
+        input_price_per_1m=1.0,
+        output_price_per_1m=5.0,
+    )  # supports_temperature defaults to True
+    kwargs = _capture_create_kwargs(pricing)
+    assert kwargs["temperature"] == AnthropicProvider.TEMPERATURE

--- a/tests/providers/test_openai_deepseek.py
+++ b/tests/providers/test_openai_deepseek.py
@@ -65,6 +65,64 @@ def test_provider_constructs_and_stores_fields(provider_cls, pricing):
 
 
 # ---------------------------------------------------------------------------
+# Request params — token-param name + temperature omission per model/provider
+# ---------------------------------------------------------------------------
+
+
+def _capture_create_kwargs(provider, prompt="x"):
+    """Run complete() with a stubbed SDK client and return the create() kwargs."""
+    from types import SimpleNamespace
+
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+        choice = SimpleNamespace(message=SimpleNamespace(content="graph TD\n a"))
+        return SimpleNamespace(usage=usage, choices=[choice])
+
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+    )
+    from maestro.schemas import RunConfig, Strategy, Tier
+
+    cfg = RunConfig(
+        strategy=Strategy.SINGLE_AGENT,
+        model=provider.pricing.model,
+        example_id="e",
+        tier=Tier.SIMPLE,
+        run_number=1,
+    )
+    provider.complete(prompt, cfg)
+    return captured
+
+
+def test_openai_uses_max_completion_tokens_and_omits_temperature():
+    """GPT-5 family: max_completion_tokens param, no temperature."""
+    pricing = ModelPricing(
+        model="gpt-5.5-2026-04-23",
+        input_price_per_1m=5.0,
+        output_price_per_1m=30.0,
+        supports_temperature=False,
+    )
+    kwargs = _capture_create_kwargs(OpenAIProvider(api_key="k", pricing=pricing))
+    assert "max_completion_tokens" in kwargs
+    assert "max_tokens" not in kwargs
+    assert "temperature" not in kwargs
+
+
+def test_deepseek_keeps_max_tokens_and_temperature():
+    """DeepSeek's OpenAI-compatible endpoint keeps max_tokens + temperature."""
+    kwargs = _capture_create_kwargs(
+        DeepSeekProvider(api_key="k", pricing=_DEEPSEEK_PRICING)
+    )
+    assert "max_tokens" in kwargs
+    assert "max_completion_tokens" not in kwargs
+    # _DEEPSEEK_PRICING leaves supports_temperature at its True default.
+    assert "temperature" in kwargs
+
+
+# ---------------------------------------------------------------------------
 # Inheritance contract — DeepSeek IS an OpenAIProvider, but points elsewhere
 # ---------------------------------------------------------------------------
 

--- a/tests/providers/test_openai_deepseek.py
+++ b/tests/providers/test_openai_deepseek.py
@@ -69,7 +69,7 @@ def test_provider_constructs_and_stores_fields(provider_cls, pricing):
 # ---------------------------------------------------------------------------
 
 
-def _capture_create_kwargs(provider, prompt="x"):
+def _capture_create_kwargs(provider: OpenAIProvider, prompt: str = "x") -> dict:
     """Run complete() with a stubbed SDK client and return the create() kwargs."""
     from types import SimpleNamespace
 

--- a/tests/providers/test_provider_dispatch.py
+++ b/tests/providers/test_provider_dispatch.py
@@ -76,9 +76,9 @@ def test_unknown_model_does_not_dispatch():
     "model_substr, expected_cls, expected_env",
     [
         ("claude-haiku-4-5", AnthropicProvider, "ANTHROPIC_API_KEY"),
-        ("gpt-4o-mini", OpenAIProvider, "OPENAI_API_KEY"),
+        ("gpt-5.4-mini-2026-03-17", OpenAIProvider, "OPENAI_API_KEY"),
         ("mistral-small", MistralProvider, "MISTRAL_API_KEY"),
-        ("gemini-2.5-flash-lite", GeminiProvider, "GEMINI_API_KEY"),
+        ("gemini-3.1-flash-lite", GeminiProvider, "GEMINI_API_KEY"),
         ("deepseek-v4-flash", DeepSeekProvider, "DEEPSEEK_API_KEY"),
     ],
 )

--- a/tests/test_run_filters.py
+++ b/tests/test_run_filters.py
@@ -50,7 +50,7 @@ def test_split_csv_trims_and_drops_empties():
 def test_valid_list_filters_build_matrix():
     args = _args(
         example="bpmn_1_03,it_1_07",
-        model="gpt-4o-mini-2024-07-18,deepseek-v4-flash",
+        model="gpt-5.4-mini-2026-03-17,deepseek-v4-flash",
         strategy="single_agent,lang_graph",
         repeats=2,
     )
@@ -59,7 +59,7 @@ def test_valid_list_filters_build_matrix():
     assert len(matrix) == 16
     assert {c["input_file"].example_id for c in matrix} == {"bpmn_1_03", "it_1_07"}
     assert {c["model_pricing"].model for c in matrix} == {
-        "gpt-4o-mini-2024-07-18",
+        "gpt-5.4-mini-2026-03-17",
         "deepseek-v4-flash",
     }
 
@@ -85,7 +85,7 @@ def test_unknown_model_exits_2_with_real_strategy():
     with pytest.raises(SystemExit) as exc:
         build_matrix(
             _args(
-                model="gpt-4o-mini-2024-07-18,typo_model",
+                model="gpt-5.4-mini-2026-03-17,typo_model",
                 strategy="single_agent",
                 example="bpmn_1_03",
             )


### PR DESCRIPTION
<h2>Summary</h2>
<p>Locks in the model set for the frozen thesis run: a frontier and an efficiency model per provider (10 total), with verified IDs and April-2026 prices, so the experiment can compare quality against cost within and across vendors. A 10-model live smoke run surfaced several provider API-contract changes the current models require; those are fixed here too. Closes #50.</p>
<p>Verified <strong>10/10 models succeed</strong> on a live single-cell run.</p>
<h2>The model matrix</h2>

Provider | Frontier | Efficiency
-- | -- | --
Anthropic | claude-opus-4-8 | claude-haiku-4-5-20251001
OpenAI | gpt-5.5-2026-04-23 | gpt-5.4-mini-2026-03-17
Mistral | mistral-medium-3-5 | mistral-small-2603
Gemini | gemini-3.5-flash | gemini-3.1-flash-lite
DeepSeek | deepseek-v4-pro | deepseek-v4-flash


<p>IDs pinned to dated snapshots where available; prices verified against each provider's pricing page (DeepSeek at the cache-miss rate, keeping tracked cost an upper bound). The two OpenAI and Gemini efficiency IDs were also refreshed to current models.</p>
<h2>Provider API fixes (surfaced by the smoke run)</h2>
<ul>
<li><strong>Temperature removal on frontier models.</strong> Opus 4.7+/Fable and the GPT-5 family removed sampling parameters and return 400 if <code>temperature</code> is sent. Added <code>ModelPricing.supports_temperature</code> (default <code>True</code>); providers omit <code>temperature</code> when it's <code>False</code>. Set on <code>claude-opus-4-8</code>, <code>gpt-5.5</code>, <code>gpt-5.4-mini</code>. The models that still accept it (Haiku, Mistral, Gemini, DeepSeek) keep it.</li>
<li><strong>OpenAI token-param rename.</strong> GPT-5 renamed <code>max_tokens</code> → <code>max_completion_tokens</code>. Made the token param a class attribute on <code>OpenAIProvider</code> so the OpenAI-compatible DeepSeek endpoint, which still expects <code>max_tokens</code>, overrides it back — preventing the change from breaking DeepSeek.</li>
</ul>
<h2>Single canonical DB location</h2>
<p>The runner (local + Docker) and the visualizer now all default to <code>out/maestro.db</code>, so results land in one place regardless of how a run was launched. Previously local runs wrote to the project root while Docker wrote to <code>out/</code>, so the dashboard's default could read the wrong DB. <code>MAESTRO_DB_PATH</code> still overrides; Docker sets it explicitly to match the mount.</p>
<h2>"Where else" updates</h2>
<ul>
<li><code>viz/theme.py</code> — provider/slot map updated to all 10 IDs (frontier = slot 1, efficiency = slot 0).</li>
<li>Stale <code>gpt-4o-mini</code> / <code>gemini-2.5</code> fixtures in run-filter and dispatch tests updated to current IDs; provider docstring examples refreshed.</li>
</ul>
<h2>Testing</h2>
<ul>
<li>222 tests pass; <code>ruff check</code> + <code>ruff format --check</code> clean.</li>
<li>New offline param-capture tests pin the per-provider request shape: <code>test_anthropic_params.py</code> (temperature omitted/included by model), and OpenAI/DeepSeek tests asserting <code>max_completion_tokens</code> vs <code>max_tokens</code> and temperature handling.</li>
<li>The provider-dispatch test confirms all 10 registered IDs resolve to a provider.</li>
<li>Live: <strong>10/10 models</strong> returned valid output on <code>bpmn_1_03 / single_agent</code>; cost data confirms the expected frontier-vs-efficiency spread.</li>
</ul>
<p>🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a></p>
<hr>
<p>After this merges, your v1.0.0 scope is down to <strong>#43 (cut the release)</strong> plus the Fable 5 review you planned. Nice work clearing the whole prep list.</p></body></html>Here's the PR description for #50:

---

**Title:** `feat(config): final model matrix + provider API fixes (#50)`

---

## Summary

Locks in the model set for the frozen thesis run: a frontier and an efficiency model per provider (10 total), with verified IDs and April-2026 prices, so the experiment can compare quality against cost within and across vendors. A 10-model live smoke run surfaced several provider API-contract changes the current models require; those are fixed here too. Closes #50.

Verified **10/10 models succeed** on a live single-cell run.

## The model matrix

| Provider | Frontier | Efficiency |
|---|---|---|
| Anthropic | `claude-opus-4-8` | `claude-haiku-4-5-20251001` |
| OpenAI | `gpt-5.5-2026-04-23` | `gpt-5.4-mini-2026-03-17` |
| Mistral | `mistral-medium-3-5` | `mistral-small-2603` |
| Gemini | `gemini-3.5-flash` | `gemini-3.1-flash-lite` |
| DeepSeek | `deepseek-v4-pro` | `deepseek-v4-flash` |

IDs pinned to dated snapshots where available; prices verified against each provider's pricing page (DeepSeek at the cache-miss rate, keeping tracked cost an upper bound). The two OpenAI and Gemini efficiency IDs were also refreshed to current models.

## Provider API fixes (surfaced by the smoke run)

- **Temperature removal on frontier models.** Opus 4.7+/Fable and the GPT-5 family removed sampling parameters and return 400 if `temperature` is sent. Added `ModelPricing.supports_temperature` (default `True`); providers omit `temperature` when it's `False`. Set on `claude-opus-4-8`, `gpt-5.5`, `gpt-5.4-mini`. The models that still accept it (Haiku, Mistral, Gemini, DeepSeek) keep it.
- **OpenAI token-param rename.** GPT-5 renamed `max_tokens` → `max_completion_tokens`. Made the token param a class attribute on `OpenAIProvider` so the OpenAI-compatible DeepSeek endpoint, which still expects `max_tokens`, overrides it back — preventing the change from breaking DeepSeek.

## Single canonical DB location

The runner (local + Docker) and the visualizer now all default to `out/maestro.db`, so results land in one place regardless of how a run was launched. Previously local runs wrote to the project root while Docker wrote to `out/`, so the dashboard's default could read the wrong DB. `MAESTRO_DB_PATH` still overrides; Docker sets it explicitly to match the mount.

## "Where else" updates

- `viz/theme.py` — provider/slot map updated to all 10 IDs (frontier = slot 1, efficiency = slot 0).
- Stale `gpt-4o-mini` / `gemini-2.5` fixtures in run-filter and dispatch tests updated to current IDs; provider docstring examples refreshed.

## Testing

- 222 tests pass; `ruff check` + `ruff format --check` clean.
- New offline param-capture tests pin the per-provider request shape: `test_anthropic_params.py` (temperature omitted/included by model), and OpenAI/DeepSeek tests asserting `max_completion_tokens` vs `max_tokens` and temperature handling.
- The provider-dispatch test confirms all 10 registered IDs resolve to a provider.
- Live: **10/10 models** returned valid output on `bpmn_1_03 / single_agent`; cost data confirms the expected frontier-vs-efficiency spread.