### PR TITLE
feat(viz): faceted run filter for the run selectors

### DIFF
--- a/src/maestro/viz/components/__init__.py
+++ b/src/maestro/viz/components/__init__.py
@@ -1,5 +1,6 @@
 """Reusable Streamlit UI components shared across viz views."""
 
 from maestro.viz.components.empty_state import empty_state
+from maestro.viz.components.run_filter_panel import render_run_filter, run_label
 
-__all__ = ["empty_state"]
+__all__ = ["empty_state", "render_run_filter", "run_label"]

--- a/src/maestro/viz/components/run_filter_panel.py
+++ b/src/maestro/viz/components/run_filter_panel.py
@@ -1,0 +1,90 @@
+"""
+MAESTRO viz — faceted run-filter panel (Streamlit shell).
+
+Renders one multi-select per facet (type / tier / strategy / model / run
+number), populated from the runs actually present, and returns the filtered
+subset. This replaces the flat run dropdowns in the Diagram Visualizer and Run
+Detail views: the user narrows by facet, then picks from the (now small)
+result. All the filtering logic lives in ``viz.run_filter`` (pure, tested); this
+module only wires it to Streamlit widgets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+from maestro.viz.run_filter import FACETS, RunFilter, apply_filter, facet_options
+from maestro.viz.theme import strategy_display_name
+
+# Human-facing labels for each facet, and per-facet option formatting.
+_FACET_LABELS = {
+    "type": "Diagram Type",
+    "tier": "Tier",
+    "strategy": "Strategy",
+    "model": "Model",
+    "run_number": "Run number",
+}
+
+# Display text for the fixed diagram-type values.
+_TYPE_DISPLAY = {"bpmn": "BPMN", "it": "IT"}
+
+
+def _format_option(facet: str, value: Any) -> str:
+    """Display text for one facet option (e.g. strategy value -> display name)."""
+    if facet == "strategy":
+        return strategy_display_name(str(value))
+    if facet == "type":
+        return _TYPE_DISPLAY.get(str(value), str(value).upper())
+    if facet == "tier":
+        return f"Tier {value}"
+    if facet == "run_number":
+        return f"Run {value}"
+    return str(value)
+
+
+def render_run_filter(
+    runs: list[dict[str, Any]], *, key_prefix: str
+) -> list[dict[str, Any]]:
+    """
+    Draw the facet multi-selects and return the filtered runs.
+
+    ``key_prefix`` namespaces the widget keys so two views (or two panels) can
+    coexist without Streamlit key collisions. Facets with only one option are
+    still shown for consistency. The count of matching runs is surfaced so the
+    user can see the filter narrowing the set.
+    """
+    options = facet_options(runs)
+
+    selected: dict[str, set[Any]] = {}
+    columns = st.columns(len(FACETS))
+    for facet, col in zip(FACETS, columns):
+        with col:
+            picked = st.multiselect(
+                _FACET_LABELS[facet],
+                options=options[facet],
+                format_func=lambda v, f=facet: _format_option(f, v),
+                key=f"{key_prefix}.facet.{facet}",
+            )
+            if picked:
+                selected[facet] = set(picked)
+
+    filtered = apply_filter(runs, RunFilter(selected))
+    st.caption(f"{len(filtered)} of {len(runs)} runs match")
+    return filtered
+
+
+def run_label(run: dict[str, Any], *, fmt_ts) -> str:
+    """
+    A unique, human-readable label for one run, used by the selectbox after
+    filtering. Includes run_number so repeats of the same cell are
+    distinguishable (the bug this feature fixes), plus the timestamp.
+
+    ``fmt_ts`` is the caller's timestamp formatter (views differ in tz handling).
+    """
+    return (
+        f"{strategy_display_name(run['strategy'])} | {run['model']} | "
+        f"tier {run['tier']} | {run['example_id']} | "
+        f"run {run.get('run_number', '?')} | {fmt_ts(run['timestamp'])}"
+    )

--- a/src/maestro/viz/components/run_filter_panel.py
+++ b/src/maestro/viz/components/run_filter_panel.py
@@ -81,7 +81,8 @@ def run_label(run: dict[str, Any], *, fmt_ts) -> str:
     filtering. Includes run_number so repeats of the same cell are
     distinguishable (the bug this feature fixes), plus the timestamp.
 
-    ``fmt_ts`` is the caller's timestamp formatter (views differ in tz handling).
+    ``fmt_ts`` is a timestamp formatter supplied by the caller (both selectors
+    pass settings.format_timestamp).
     """
     return (
         f"{strategy_display_name(run['strategy'])} | {run['model']} | "

--- a/src/maestro/viz/queries.py
+++ b/src/maestro/viz/queries.py
@@ -345,13 +345,19 @@ def distinct_strategies(
 def list_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     """
     Every run as a selectable entry: run_id, strategy, model, tier, example_id,
-    timestamp. Most recent first. Empty list if no runs.
+    run_number, timestamp. Most recent first. Empty list if no runs.
+
+    Returns all runs, controls included; each view filters to the subset it
+    needs (the run selectors drop controls via the faceted filter, since a
+    control produces no model-generated diagram to inspect). run_number is
+    included so selectors can distinguish repeats of the same cell, and so the
+    faceted filter can offer a run-number facet (see viz.run_filter).
     """
     if not table_exists(conn, "run_configs"):
         return []
     rows = conn.execute(
         """
-        SELECT run_id, strategy, model, tier, example_id, timestamp
+        SELECT run_id, strategy, model, tier, example_id, run_number, timestamp
         FROM run_configs
         ORDER BY timestamp DESC
         """

--- a/src/maestro/viz/run_filter.py
+++ b/src/maestro/viz/run_filter.py
@@ -1,0 +1,139 @@
+"""
+MAESTRO viz — faceted filtering of runs (pure logic, no Streamlit).
+
+The dashboard's run selectors used to be flat dropdowns over every run, which
+breaks down at scale (a ~1000-row matrix is unusable, and repeats of one cell
+share a label). This module is the testable core of the fix: given the run list
+(from ``queries.list_runs``) and a set of selected facet values, it derives the
+available facet options and returns the filtered subset. The Streamlit panel in
+``components.run_filter_panel`` is a thin shell around these functions.
+
+Facet semantics: multi-select per facet; facets combine with AND across and OR
+within. An empty selection for a facet means "no constraint" (all values pass).
+
+The ``type`` facet (bpmn / it) is derived from the ``example_id`` prefix; every
+registered id is ``<type>_<tier>_<nn>`` (e.g. ``bpmn_1_03``, ``it_2_19``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from maestro.experiment_config import CONTROL_STRATEGIES
+from maestro.schemas import Strategy
+
+# Facet keys, in display order. Each maps a run dict to a comparable value via
+# _FACET_ACCESSORS below.
+FACETS: tuple[str, ...] = ("type", "tier", "strategy", "model", "run_number")
+
+
+def _run_type(run: dict[str, Any]) -> str:
+    """Diagram type (bpmn / it) from the example_id prefix."""
+    example_id = run.get("example_id") or ""
+    return example_id.split("_", 1)[0] if example_id else ""
+
+
+_FACET_ACCESSORS = {
+    "type": _run_type,
+    "tier": lambda r: r.get("tier"),
+    "strategy": lambda r: r.get("strategy"),
+    "model": lambda r: r.get("model"),
+    "run_number": lambda r: r.get("run_number"),
+}
+
+# Facets whose option set is a fixed, known domain rather than derived from the
+# data. These always offer every value (so the filter reads as intentional even
+# before the full matrix has run); facets not listed here (model, run_number)
+# derive their options from the runs present. The values match what the
+# accessors above return.
+#
+# strategy is sourced from the Strategy enum (minus controls) rather than a
+# literal, so adding an orchestration strategy in code surfaces it in the filter
+# automatically with no edit here. Controls are deterministic pipeline checks,
+# not strategies under study, and are excluded from the selector. model stays
+# derived: its ids are version-pinned and change per matrix, so a hardcoded list
+# would drift and could hide an older model still in the data.
+_FIXED_FACET_OPTIONS: dict[str, list[Any]] = {
+    "type": ["bpmn", "it"],
+    "tier": [1, 2, 3],
+    "strategy": [s.value for s in Strategy if s not in CONTROL_STRATEGIES],
+}
+
+# DB strategy values that are controls, for exclude_controls below.
+_CONTROL_STRATEGY_VALUES: frozenset[str] = frozenset(
+    s.value for s in CONTROL_STRATEGIES
+)
+
+
+def exclude_controls(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Drop control runs (null/copy/ground-truth) from a run list.
+
+    Controls are kept in the DB (they prove the scoring floor/ceiling and feed
+    reference lines in aggregate views), so list_runs returns them. Views that
+    have no use for them — the per-run selectors, where a control produces no
+    model-generated diagram to inspect — call this to drop them. Keeping the
+    exclusion here (not in the query) lets each view/chart decide for itself.
+    """
+    return [r for r in runs if r.get("strategy") not in _CONTROL_STRATEGY_VALUES]
+
+
+@dataclass
+class RunFilter:
+    """
+    Selected facet values. Each entry maps a facet key to the set of values the
+    user picked for it; an absent or empty key means that facet is unconstrained.
+    """
+
+    selected: dict[str, set[Any]] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        """True when no facet constrains the result (everything passes)."""
+        return not any(self.selected.get(f) for f in FACETS)
+
+
+def facet_options(runs: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    """
+    The option list for each facet.
+
+    Facets with a fixed domain (type, tier) always offer every value, so the
+    filter reads as intentional even before the full matrix has run. The rest
+    (strategy, model, run_number) derive their options from ``runs`` so only
+    values actually present are offered, and model ids are never hardcoded.
+    Returns one list per facet; derived facets with no values map to [].
+    """
+    options: dict[str, list[Any]] = {}
+    for facet in FACETS:
+        if facet in _FIXED_FACET_OPTIONS:
+            options[facet] = list(_FIXED_FACET_OPTIONS[facet])
+            continue
+        accessor = _FACET_ACCESSORS[facet]
+        values = {accessor(r) for r in runs}
+        values.discard(None)
+        values.discard("")
+        options[facet] = sorted(values)
+    return options
+
+
+def apply_filter(
+    runs: list[dict[str, Any]], run_filter: RunFilter
+) -> list[dict[str, Any]]:
+    """
+    Return the runs matching ``run_filter``: AND across facets, OR within a
+    facet. An unconstrained facet (no values selected) imposes no restriction.
+    Order is preserved from the input list.
+    """
+    if run_filter.is_empty():
+        return list(runs)
+
+    def matches(run: dict[str, Any]) -> bool:
+        for facet in FACETS:
+            chosen = run_filter.selected.get(facet)
+            if not chosen:
+                continue  # unconstrained facet
+            if _FACET_ACCESSORS[facet](run) not in chosen:
+                return False
+        return True
+
+    return [r for r in runs if matches(r)]

--- a/src/maestro/viz/settings.py
+++ b/src/maestro/viz/settings.py
@@ -94,6 +94,26 @@ def current_settings() -> ViewSettings:
     )
 
 
+def format_timestamp(ts: str | None) -> str:
+    """
+    Format a stored UTC timestamp string for display in the configured tz.
+
+    Shared by the run selectors so timestamps render consistently. Returns ""
+    for an empty value and passes a non-ISO string through unchanged.
+    """
+    from datetime import datetime
+
+    from maestro.analysis.timestamps import format_for_display
+
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return ts
+    return format_for_display(dt, current_settings().display_tz)
+
+
 def render_settings_panel() -> None:
     """
     Render the gear/settings controls. Call inside the sidebar (the caller

--- a/src/maestro/viz/theme.py
+++ b/src/maestro/viz/theme.py
@@ -82,6 +82,16 @@ _STRATEGY_VALUE_TO_NAME: dict[str, str] = {
     "lang_graph": "LangGraph",
 }
 
+# Display names for the control strategies. Kept separate from the map above
+# because that one drives strategy_color (its keys must exist in
+# STRATEGY_COLORS, which controls deliberately do not). These are display-only,
+# used by strategy_display_name so the run-filter offers readable labels.
+_CONTROL_VALUE_TO_NAME: dict[str, str] = {
+    "null_control": "Null Control",
+    "copy_control": "Copy Control",
+    "ground_truth_control": "Ground Truth Control",
+}
+
 # Model id (run_configs.model) → (provider display name, slot) where slot is
 # 0 for the efficiency model and 1 for the frontier model. Keep this in sync
 # with experiment_config.MODELS (two ids per provider).
@@ -179,10 +189,14 @@ def strategy_color(strategy_value: str) -> str:
 def strategy_display_name(strategy_value: str) -> str:
     """
     Human display name for a DB strategy value (e.g. ``"single_agent"`` →
-    ``"Single Agent"``), per the design guide. Falls back to the raw value for
-    anything unmapped (e.g. control strategies), so charts always have a label.
+    ``"Single Agent"``, ``"null_control"`` → ``"Null Control"``), per the design
+    guide. Falls back to the raw value for anything unmapped, so a label is
+    always available.
     """
-    return _STRATEGY_VALUE_TO_NAME.get(strategy_value, strategy_value)
+    return _STRATEGY_VALUE_TO_NAME.get(
+        strategy_value,
+        _CONTROL_VALUE_TO_NAME.get(strategy_value, strategy_value),
+    )
 
 
 def model_color(model_id: str) -> str:

--- a/src/maestro/viz/views/diagram_visualizer.py
+++ b/src/maestro/viz/views/diagram_visualizer.py
@@ -23,9 +23,9 @@ from maestro.experiment_config import INPUTS
 from maestro.viz import db as viz_db
 from maestro.viz import queries as viz_queries
 from maestro.viz import settings as viz_settings
-from maestro.viz.components import empty_state
+from maestro.viz.components import empty_state, render_run_filter, run_label
 from maestro.viz.mermaid_render import mmdc_available, render_mermaid_svg
-from maestro.viz.theme import strategy_display_name
+from maestro.viz.run_filter import exclude_controls
 
 # example_id → InputFile, for resolving the ground-truth file path.
 _INPUTS_BY_ID = {inp.example_id: inp for inp in INPUTS}
@@ -45,21 +45,28 @@ def render() -> None:
         return
 
     with viz_db.connect(db_path) as conn:
-        runs = viz_queries.list_runs(conn)
+        # Controls (null/copy/ground-truth) have no generated diagram to inspect
+        # here, so drop them from this per-run selector.
+        runs = exclude_controls(viz_queries.list_runs(conn))
         if not runs:
             empty_state("No runs available.")
             return
 
+        # Faceted filter narrows the run set; the selectbox then picks from the
+        # (small) result. run_label includes run_number so repeats of the same
+        # cell are individually selectable.
+        filtered = render_run_filter(runs, key_prefix="diagram_visualizer")
+        if not filtered:
+            empty_state("No runs match the active filter.")
+            return
+
         labels = {
-            r["run_id"]: (
-                f"{strategy_display_name(r['strategy'])} | {r['model']} | "
-                f"tier {r['tier']} | {r['example_id']}"
-            )
-            for r in runs
+            r["run_id"]: run_label(r, fmt_ts=viz_settings.format_timestamp)
+            for r in filtered
         }
         run_id = st.selectbox(
             "Run",
-            options=[r["run_id"] for r in runs],
+            options=[r["run_id"] for r in filtered],
             format_func=lambda rid: labels[rid],
         )
         detail = viz_queries.run_detail(conn, run_id)

--- a/src/maestro/viz/views/run_detail.py
+++ b/src/maestro/viz/views/run_detail.py
@@ -18,8 +18,8 @@ from maestro.viz import db as viz_db
 from maestro.viz import queries as viz_queries
 from maestro.viz import settings as viz_settings
 from maestro.viz.chart import new_figure, render_chart
-from maestro.viz.components import empty_state
-from maestro.viz.theme import strategy_display_name
+from maestro.viz.components import empty_state, render_run_filter, run_label
+from maestro.viz.run_filter import exclude_controls
 
 # example_id → InputFile, for resolving input + ground-truth file paths. The
 # DB stores only example_id; the actual files live on disk per the config.
@@ -48,21 +48,27 @@ def render() -> None:
         return
 
     with viz_db.connect(db_path) as conn:
-        runs = viz_queries.list_runs(conn)
+        # Controls (null/copy/ground-truth) echo input/ground-truth rather than
+        # a generated diagram, so drop them from this per-run selector.
+        runs = exclude_controls(viz_queries.list_runs(conn))
         if not runs:
             empty_state("No runs available.")
             return
 
+        # Faceted filter, then a selectbox over the narrowed set. run_label
+        # includes run_number so repeats of the same cell are distinguishable.
+        filtered = render_run_filter(runs, key_prefix="run_detail")
+        if not filtered:
+            empty_state("No runs match the active filter.")
+            return
+
         labels = {
-            r["run_id"]: (
-                f"{strategy_display_name(r['strategy'])} | {r['model']} | "
-                f"tier {r['tier']} | {_fmt_ts(r['timestamp'])}"
-            )
-            for r in runs
+            r["run_id"]: run_label(r, fmt_ts=viz_settings.format_timestamp)
+            for r in filtered
         }
         run_id = st.selectbox(
             "Run",
-            options=[r["run_id"] for r in runs],
+            options=[r["run_id"] for r in filtered],
             format_func=lambda rid: labels[rid],
         )
 
@@ -79,22 +85,6 @@ def render() -> None:
     if subs:
         st.divider()
         _render_sub_trace(subs)
-
-
-def _fmt_ts(ts: str) -> str:
-    """Format a stored UTC timestamp for display in the configured tz."""
-    from datetime import datetime
-
-    from maestro.analysis.timestamps import format_for_display
-
-    if not ts:
-        return ""
-    cfg = viz_settings.current_settings()
-    try:
-        dt = datetime.fromisoformat(ts)
-    except (ValueError, TypeError):
-        return ts
-    return format_for_display(dt, cfg.display_tz)
 
 
 def _render_io(detail: dict) -> None:

--- a/tests/viz/test_run_filter.py
+++ b/tests/viz/test_run_filter.py
@@ -1,0 +1,193 @@
+"""
+Tests for the faceted run-filter logic (viz.run_filter).
+
+The filtering core is pure Python (no Streamlit), so facet extraction and the
+AND-across / OR-within semantics are unit-tested directly here. The Streamlit
+panel that wraps these functions is a thin shell and is not unit-tested.
+"""
+
+from __future__ import annotations
+
+from maestro.viz.run_filter import (
+    FACETS,
+    RunFilter,
+    apply_filter,
+    exclude_controls,
+    facet_options,
+)
+
+
+def _run(
+    *, example_id: str, tier: int, strategy: str, model: str, run_number: int
+) -> dict:
+    """Build a run dict shaped like queries.list_runs rows."""
+    return {
+        "run_id": f"{example_id}-{strategy}-{model}-{run_number}",
+        "example_id": example_id,
+        "tier": tier,
+        "strategy": strategy,
+        "model": model,
+        "run_number": run_number,
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+
+
+_RUNS = [
+    _run(
+        example_id="bpmn_1_03",
+        tier=1,
+        strategy="single_agent",
+        model="gpt",
+        run_number=1,
+    ),
+    _run(
+        example_id="bpmn_1_03",
+        tier=1,
+        strategy="single_agent",
+        model="gpt",
+        run_number=2,
+    ),
+    _run(
+        example_id="it_2_19",
+        tier=2,
+        strategy="lang_graph",
+        model="deepseek",
+        run_number=1,
+    ),
+    _run(
+        example_id="it_2_19", tier=2, strategy="single_agent", model="gpt", run_number=1
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# facet_options
+# ---------------------------------------------------------------------------
+
+
+def _orchestration_strategies() -> list[str]:
+    from maestro.experiment_config import CONTROL_STRATEGIES
+    from maestro.schemas import Strategy
+
+    return [s.value for s in Strategy if s not in CONTROL_STRATEGIES]
+
+
+def test_fixed_facets_always_offer_full_domain():
+    # type, tier, strategy are fixed domains: every value is offered regardless
+    # of the data present (here the runs only cover tiers 1-2 and two
+    # strategies, but the full domains stay selectable). strategy is sourced
+    # from the Strategy enum minus controls, so the four orchestration
+    # strategies under study are offered and controls are excluded.
+    opts = facet_options(_RUNS)
+    assert opts["type"] == ["bpmn", "it"]
+    assert opts["tier"] == [1, 2, 3]
+    assert opts["strategy"] == _orchestration_strategies()
+    assert "null_control" not in opts["strategy"]
+
+
+def test_derived_facets_distinct_and_sorted():
+    # model / run_number derive their options from the runs present.
+    opts = facet_options(_RUNS)
+    assert opts["model"] == ["deepseek", "gpt"]
+    assert opts["run_number"] == [1, 2]
+
+
+def test_facet_options_empty_runs():
+    opts = facet_options([])
+    assert set(opts.keys()) == set(FACETS)
+    # Fixed facets still offer their full domain; derived facets are empty.
+    assert opts["type"] == ["bpmn", "it"]
+    assert opts["tier"] == [1, 2, 3]
+    assert opts["strategy"] == _orchestration_strategies()
+    assert opts["model"] == []
+    assert opts["run_number"] == []
+
+
+def test_derived_facet_drops_none_and_blank():
+    runs = [
+        _run(
+            example_id="bpmn_1_03",
+            tier=1,
+            strategy="single_agent",
+            model="",
+            run_number=1,
+        )
+    ]
+    opts = facet_options(runs)
+    assert opts["model"] == []  # blank model yields no derived option
+
+
+# ---------------------------------------------------------------------------
+# apply_filter
+# ---------------------------------------------------------------------------
+
+
+def test_empty_filter_returns_all():
+    assert apply_filter(_RUNS, RunFilter()) == _RUNS
+
+
+def test_single_facet_or_within():
+    # type in {bpmn} -> only the two bpmn runs
+    out = apply_filter(_RUNS, RunFilter({"type": {"bpmn"}}))
+    assert len(out) == 2
+    assert all(r["example_id"].startswith("bpmn") for r in out)
+
+
+def test_or_within_multiple_values():
+    # model in {gpt, deepseek} -> all four runs
+    out = apply_filter(_RUNS, RunFilter({"model": {"gpt", "deepseek"}}))
+    assert len(out) == 4
+
+
+def test_and_across_facets():
+    # type=it AND strategy=single_agent -> only the it_2_19 single_agent run
+    out = apply_filter(_RUNS, RunFilter({"type": {"it"}, "strategy": {"single_agent"}}))
+    assert len(out) == 1
+    assert out[0]["example_id"] == "it_2_19"
+    assert out[0]["strategy"] == "single_agent"
+
+
+def test_run_number_facet_distinguishes_repeats():
+    # The repeats bug: both bpmn runs share strategy/model/tier; run_number splits them.
+    out = apply_filter(_RUNS, RunFilter({"run_number": {2}}))
+    assert len(out) == 1
+    assert out[0]["run_number"] == 2
+
+
+def test_no_match_returns_empty():
+    out = apply_filter(_RUNS, RunFilter({"tier": {3}}))
+    assert out == []
+
+
+def test_order_preserved():
+    out = apply_filter(_RUNS, RunFilter({"model": {"gpt"}}))
+    assert [r["run_id"] for r in out] == [
+        r["run_id"] for r in _RUNS if r["model"] == "gpt"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# exclude_controls
+# ---------------------------------------------------------------------------
+
+
+def test_exclude_controls_drops_only_controls():
+    runs = _RUNS + [
+        _run(
+            example_id="bpmn_1_03",
+            tier=1,
+            strategy="null_control",
+            model="control",
+            run_number=1,
+        ),
+        _run(
+            example_id="it_2_19",
+            tier=2,
+            strategy="ground_truth_control",
+            model="control",
+            run_number=1,
+        ),
+    ]
+    out = exclude_controls(runs)
+    assert out == _RUNS  # the two control runs are dropped, order preserved
+    assert all("control" not in r["strategy"] for r in out)

--- a/tests/viz/test_views.py
+++ b/tests/viz/test_views.py
@@ -257,7 +257,10 @@ def test_list_and_detail_roundtrip():
         conn, strategy="single_agent", model="gpt-4o-mini-2024-07-18", tier=1, f1=0.6
     )
     runs = q.list_runs(conn)
-    assert any(r["run_id"] == rid for r in runs)
+    row = next(r for r in runs if r["run_id"] == rid)
+    # run_number is exposed so selectors can distinguish repeats and the
+    # faceted filter can offer a run-number facet.
+    assert row["run_number"] == 1
     detail = q.run_detail(conn, rid)
     assert detail is not None
     assert detail["strategy"] == "single_agent"


### PR DESCRIPTION
## Summary

Replaces the flat run dropdowns in **Diagram Visualizer** and **Run Detail** with a reusable faceted filter, modelled on e-commerce filters: narrow the run set by facet, then pick from the (now small) result. Closes #64.

This also fixes the **indistinguishable-repeats bug** — with repeats, multiple runs shared the same `strategy | model | tier | example` label and selecting them appeared to do nothing. `run_number` is now part of the run list and the selector labels, so repeats are individually selectable.

## Design

Layered to match the existing viz split (data / pure-logic / UI / views):

- **`run_filter.py`** (new, pure Python, no Streamlit) — the testable core: `facet_options()`, `apply_filter()` (AND across facets, OR within), `exclude_controls()`. The `type` facet is derived from the `example_id` prefix.
- **`components/run_filter_panel.py`** (new) — a thin Streamlit shell: one multiselect per facet, a "N of M runs match" caption, and `run_label()` (includes `run_number` + timestamp).
- **Both selector views** — flat dropdown → filter panel → selectbox over the narrowed set, with a "no runs match" empty-state.
- **`queries.list_runs`** — now returns `run_number`.
- **`settings.format_timestamp`** — extracted a shared timestamp formatter the selectors both use (de-duplicated Run Detail's local helper).

### Facet option sources

| Facet | Source | Rationale |
|---|---|---|
| Diagram Type (BPMN, IT) | fixed literal | tiny static domain |
| Tier (1, 2, 3) | fixed literal | static domain |
| Strategy | `Strategy` enum **minus controls** | closed code-defined set; new orchestration strategies appear automatically; controls auto-excluded |
| Model | DB-derived | version-pinned ids change per matrix; hardcoding would drift and could hide an older model still in the data |
| Run number | DB-derived | varies per run |

### Controls

Controls (null / copy / ground-truth) **stay in the dataset** — `list_runs` returns them, since they prove the scoring floor/ceiling and will feed reference lines in the future aggregate views. Each view decides for itself: the run selectors call `exclude_controls()` (a control has no model-generated diagram to inspect), while later charts can keep them. The policy lives in the view, not the query.

## Scope

In scope (per #64): the reusable filter component + adoption in the two run-selector views, facet values from the DB, empty/no-match states, filter-logic tests. Out of scope (deferred to v1.0.1): filtered aggregation across the stats/chart views, an "All" affordance for those views, saved presets, URL-encoded state.

## Testing

- 234 tests pass; `ruff check` + `ruff format --check` clean.
- New `tests/viz/test_run_filter.py` covers facet extraction (fixed vs derived), AND-across / OR-within semantics, the run-number facet distinguishing repeats, and `exclude_controls`.
- `list_runs` now asserted to expose `run_number`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faceted filtering panel for runs—filter by strategy, model, type, tier, and run number across visualization views.
  * Improved run display labels with consistent timestamp formatting and run identifiers.

* **Improvements**
  * Control runs are now excluded from the main run selectors.
  * Enhanced timestamp formatting for better readability across the visualization interface.

* **Tests**
  * Added comprehensive unit tests for run filtering logic and display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->