### PR TITLE
refactor: aggregate inferential tests to per-cell means under explicit scoring conventions

### DIFF
--- a/src/maestro/analysis/__init__.py
+++ b/src/maestro/analysis/__init__.py
@@ -4,8 +4,12 @@
 # ``from maestro.analysis import describe, anova_strategy`` without reaching
 # into the submodule. The CLI lives in maestro.analysis.__main__.
 from maestro.analysis.statistics import (
+    DEFAULT_CONVENTION,
+    INTENT_TO_TREAT,
     PRIMARY_DV,
     SCHEMA_VERSION,
+    VALID_ONLY,
+    aggregate_experimental,
     anova_strategy,
     anova_strategy_by_model,
     anova_strategy_by_tier,
@@ -13,6 +17,7 @@ from maestro.analysis.statistics import (
     effect_sizes,
     error_taxonomy_by_strategy,
     load_dataframe,
+    mixed_effects_robustness,
     posthoc_strategy,
     tradeoff_correctness_efficiency,
 )
@@ -34,8 +39,12 @@ __all__ = [
     "format_for_display",
     "resolve_display_tz",
     # statistics
+    "DEFAULT_CONVENTION",
+    "INTENT_TO_TREAT",
     "PRIMARY_DV",
     "SCHEMA_VERSION",
+    "VALID_ONLY",
+    "aggregate_experimental",
     "anova_strategy",
     "anova_strategy_by_model",
     "anova_strategy_by_tier",
@@ -43,6 +52,7 @@ __all__ = [
     "effect_sizes",
     "error_taxonomy_by_strategy",
     "load_dataframe",
+    "mixed_effects_robustness",
     "posthoc_strategy",
     "tradeoff_correctness_efficiency",
 ]

--- a/src/maestro/analysis/__main__.py
+++ b/src/maestro/analysis/__main__.py
@@ -23,7 +23,9 @@ from pathlib import Path
 from typing import Any, Callable
 
 from maestro.analysis.statistics import (
+    INTENT_TO_TREAT,
     SCHEMA_VERSION,
+    VALID_ONLY,
     anova_strategy,
     anova_strategy_by_model,
     anova_strategy_by_tier,
@@ -31,6 +33,7 @@ from maestro.analysis.statistics import (
     effect_sizes,
     error_taxonomy_by_strategy,
     load_dataframe,
+    mixed_effects_robustness,
     posthoc_strategy,
     tradeoff_correctness_efficiency,
 )
@@ -43,32 +46,51 @@ from maestro.experiment_config import DB_PATH
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_OUT_DIR = _PROJECT_ROOT / "output" / "analysis"
 
-# (filename, callable) for each analysis. Order is the report order.
-# Callables take the DataFrame and return a JSON-serializable dict.
+# The scoring conventions to emit, primary first. Every convention-dependent
+# analysis is written once per convention, so the results chapter can report
+# intent_to_treat as the headline and valid_only as a sensitivity check.
+_CONVENTIONS = (INTENT_TO_TREAT, VALID_ONLY)
+
+# Convention-independent analyses: (filename, callable). These take only the
+# DataFrame and do not depend on a scoring convention. Descriptives keep the
+# raw per-run grain and include controls; the taxonomy and trade-off outputs
+# are descriptive summaries, not inferential tests.
 _ANALYSES: list[tuple[str, Callable]] = [
     ("descriptive.json", describe),
-    ("anova_strategy.json", anova_strategy),
-    ("anova_strategy_by_tier.json", anova_strategy_by_tier),
-    ("anova_strategy_by_model.json", anova_strategy_by_model),
-    ("posthoc_strategy.json", posthoc_strategy),
-    ("effect_sizes.json", effect_sizes),
     ("error_taxonomy_by_strategy.json", error_taxonomy_by_strategy),
     ("tradeoff_correctness_efficiency.json", tradeoff_correctness_efficiency),
+]
+
+# Convention-dependent analyses: (stem, callable). Each is emitted once per
+# scoring convention as ``<stem>__<convention>.json`` (content-based naming:
+# the filename states both the test and the convention, so a file is never
+# ambiguous about which numbers it holds). The callable takes
+# (DataFrame, convention).
+_CONVENTION_ANALYSES: list[tuple[str, Callable]] = [
+    ("anova_strategy", anova_strategy),
+    ("anova_strategy_by_tier", anova_strategy_by_tier),
+    ("anova_strategy_by_model", anova_strategy_by_model),
+    ("posthoc_strategy", posthoc_strategy),
+    ("effect_sizes", effect_sizes),
+    ("mixed_effects_robustness", mixed_effects_robustness),
 ]
 
 # RQ -> file mapping, surfaced in report.md. This is the *interpretation*
 # layer: it lives in the human-facing report, never in the data files (so
 # the JSON stays reusable if the RQs are reframed). Keep in sync with the
-# thesis RQ definitions.
+# thesis RQ definitions. Inferential outputs are emitted per scoring convention
+# as ``<stem>__<convention>.json``; the map names the intent-to-treat file (the
+# primary convention), and the parallel ``__valid_only`` file is the
+# sensitivity check for the same question.
 _RQ_MAP: list[tuple[str, str, str]] = [
     (
         "RQ1",
-        "anova_strategy.json + posthoc_strategy.json",
+        "anova_strategy__intent_to_treat.json + posthoc_strategy__intent_to_treat.json",
         "Multi-agent strategies vs. single-agent baseline correctness.",
     ),
     (
         "RQ2",
-        "anova_strategy_by_tier.json",
+        "anova_strategy_by_tier__intent_to_treat.json",
         "Does input complexity moderate the multi-agent advantage "
         "(strategy×tier interaction)?",
     ),
@@ -80,14 +102,15 @@ _RQ_MAP: list[tuple[str, str, str]] = [
     ),
     (
         "RQ4",
-        "tradeoff_correctness_efficiency.json + effect_sizes.json",
+        "tradeoff_correctness_efficiency.json + effect_sizes__intent_to_treat.json",
         "Correctness vs. efficiency trade-off across strategies.",
     ),
     (
         "robustness",
-        "anova_strategy_by_model.json",
+        "anova_strategy_by_model__intent_to_treat.json + "
+        "mixed_effects_robustness__intent_to_treat.json",
         "Cross-cutting: does the strategy effect hold across models / "
-        "providers (strategy×model interaction)?",
+        "providers, and does it survive a mixed-effects model?",
     ),
 ]
 
@@ -196,22 +219,60 @@ def _build_report(
     desc = results.get("descriptive.json", {})
     n_cells = len(desc.get("cells", []))
     lines.append(f"- Descriptive cells: {n_cells}")
+    lines.append(
+        f"- Primary scoring convention: `{INTENT_TO_TREAT}` "
+        f"(sensitivity check: `{VALID_ONLY}`)"
+    )
+    lines.append(
+        "- Inferential unit of analysis: mean over repeats per (strategy, model, input)"
+    )
 
-    _summarize_anova(lines, "RQ1: strategy", results.get("anova_strategy.json", {}))
+    # Headline numbers use the primary (intent_to_treat) convention; the
+    # __valid_only files carry the sensitivity check for the same tests.
     _summarize_anova(
-        lines, "RQ2: strategy×tier", results.get("anova_strategy_by_tier.json", {})
+        lines,
+        "RQ1: strategy",
+        results.get("anova_strategy__intent_to_treat.json", {}),
+    )
+    _summarize_anova(
+        lines,
+        "RQ2: strategy×tier",
+        results.get("anova_strategy_by_tier__intent_to_treat.json", {}),
     )
     _summarize_anova(
         lines,
         "robustness: strategy×model",
-        results.get("anova_strategy_by_model.json", {}),
+        results.get("anova_strategy_by_model__intent_to_treat.json", {}),
     )
     lines.append("")
 
     lines.append("## Notes")
     lines.append("")
     lines.append(
-        "- Analyses reported as *skipped* lacked a factor with ≥2 observed "
+        "- Inferential tests run on per-cell means (one observation per "
+        "strategy x model x input, repeats averaged), not the raw runs. "
+        "Fitting the raw repeats would be pseudoreplication and overstate "
+        "significance."
+    )
+    lines.append(
+        f"- Two scoring conventions are reported. `{INTENT_TO_TREAT}` "
+        "(primary) scores every run, with a failed or unrenderable diagram "
+        "counting 0.0: it measures what a user receives, and does not let a "
+        "strategy look good by failing and being dropped. `{valid}` "
+        "(sensitivity) keeps only renderable diagrams. Failures are not "
+        "random (they concentrate in the more complex orchestrations), so the "
+        "two conventions can disagree, and that is the point of reporting "
+        "both.".format(valid=VALID_ONLY)
+    )
+    lines.append(
+        "- `mixed_effects_robustness__*.json` refits the strategy x tier "
+        "effect on the un-aggregated runs with crossed random intercepts for "
+        "model and input, as a check that the aggregated ANOVA conclusion "
+        "survives a model of the grouping structure. It self-skips if the "
+        "mixed model does not converge."
+    )
+    lines.append(
+        "- Analyses reported as *skipped* lacked a factor with >= 2 observed "
         "levels in the current corpus (e.g. a single input tier). They "
         "recompute automatically once the corpus grows: no code change."
     )
@@ -293,6 +354,14 @@ def main(argv: list[str] | None = None) -> int:
         payload = fn(df)
         results[filename] = payload
         _write_json(run_dir / filename, payload)
+
+    # Convention-dependent analyses: one file per (analysis, convention).
+    for stem, fn in _CONVENTION_ANALYSES:
+        for convention in _CONVENTIONS:
+            filename = f"{stem}__{convention}.json"
+            payload = fn(df, convention)
+            results[filename] = payload
+            _write_json(run_dir / filename, payload)
 
     # report.md (interpretation layer).
     report = _build_report(

--- a/src/maestro/analysis/statistics.py
+++ b/src/maestro/analysis/statistics.py
@@ -6,17 +6,53 @@ paper-ready statistics as JSON plus an assembled ``report.md``. The
 visualizer is a separate consumer of these JSON outputs; it does
 not duplicate the math here.
 
+## Unit of analysis and scoring convention
+
+Two choices shape every inferential number here, and both are recorded in
+each emitted file's metadata so a reader never has to guess.
+
+*Unit of analysis.* The five repeats of a cell are technical replicates,
+not independent observations. Fitting the raw per-run rows would treat
+correlated repeats as independent and overstate significance
+(pseudoreplication). All inferential tests therefore run on **per-cell
+means**: one observation per (strategy, model, input) after averaging the
+repeats. Descriptives keep the per-run grain (they report spread, not a
+test).
+
+*Scoring convention.* A run can succeed with a good diagram, succeed with
+a diagram that does not render, or fail outright with no scored row at all.
+The two conventions below make explicit which of those count and how; the
+old implicit behaviour (drop failures, keep an unrenderable diagram at its
+partial F1) was neither, so it is gone.
+
+- ``intent_to_treat`` (the primary convention): every experimental run
+  counts. A run that failed, or whose diagram does not parse, scores 0.0
+  on the primary DV. This measures what a user actually receives, and it
+  denies a strategy the chance to look good by failing and being dropped.
+  Because failures are informative here (they concentrate in the more
+  complex orchestrations), excluding them would bias the comparison.
+- ``valid_only`` (a robustness convention): keep only runs whose diagram
+  parsed. This measures quality *given* the model produced a renderable
+  diagram, and is reported alongside intent-to-treat as a sensitivity
+  check, not as the headline.
+
 ## What this module computes
 
 - **Descriptives**: per-cell (strategy × model × tier) mean / median / std
-  for the primary correctness DV and the efficiency DVs. Controls are
-  *included* here (they are the sanity floor/ceiling anchors).
-- **ANOVA**: factorial models on the primary correctness DV. Controls are
+  for the primary correctness DV and the efficiency DVs, on the raw per-run
+  grain. Controls are *included* here (they are the sanity floor/ceiling
+  anchors).
+- **ANOVA**: factorial models on the primary correctness DV, fit on the
+  per-cell aggregated frame under a chosen scoring convention. Controls are
   *excluded* (their F1 is 0 or 1 by construction and would distort the
   F-statistic). ``single_agent`` is the reference level: it is the
   comparison *baseline*, distinct from the control conditions.
 - **Effect sizes**: partial η² per ANOVA term, Cohen's d for pairwise
-  strategy contrasts.
+  strategy contrasts (also on the aggregated frame).
+- **Mixed-effects robustness**: a ``MixedLM`` on the un-aggregated rows with
+  random intercepts for model and input, as a check that the aggregated
+  ANOVA conclusion survives a model that accounts for the crossed grouping
+  structure directly instead of by pre-averaging.
 - **Error taxonomy**: descriptive characterization of the eight taxonomy
   counts per strategy (exploratory; no inferential test).
 - **Correctness/efficiency trade-off**: per-strategy correctness against
@@ -45,7 +81,7 @@ statistics unchanged once the corpus grows.
 from __future__ import annotations
 
 import sqlite3
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from maestro.db.queries import fetch_analysis_rows
 from maestro.experiment_config import CONTROL_STRATEGIES
@@ -54,9 +90,27 @@ from maestro.schemas import Strategy
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
 
-# Version of the JSON output contract. Bump on any breaking change to the
-# shape of the emitted files so the visualizer can detect it.
-SCHEMA_VERSION = "1.0"
+# Version of the JSON output contract. Bumped to 1.1 when the inferential
+# path moved to per-cell aggregation under an explicit scoring convention:
+# the numbers changed meaning, so the contract version had to move with them.
+SCHEMA_VERSION = "1.1"
+
+# Scoring conventions for the primary DV. See the module docstring for the
+# full rationale; in short, ``intent_to_treat`` scores failures and
+# unrenderable diagrams as 0.0 (what the user receives), ``valid_only`` keeps
+# only renderable diagrams (quality given a parse).
+ScoringConvention = Literal["intent_to_treat", "valid_only"]
+INTENT_TO_TREAT: ScoringConvention = "intent_to_treat"
+VALID_ONLY: ScoringConvention = "valid_only"
+
+# The primary convention: the headline inferential numbers use it. valid_only
+# rides along as a robustness/sensitivity report.
+DEFAULT_CONVENTION: ScoringConvention = INTENT_TO_TREAT
+
+# The columns that identify one experimental cell. Repeats (run_number) are
+# averaged away within a cell; tier is carried along because it is a function
+# of example_id, not an independent grouping key.
+_CELL_KEYS = ("strategy", "model", "example_id")
 
 # Primary correctness dependent variable. The metric_results table carries
 # a family of F1 scores; entity_id_f1 (exact ID match) is the strictest
@@ -120,6 +174,81 @@ def _experimental(df: "pd.DataFrame") -> "pd.DataFrame":
     if df.empty:
         return df
     return df[~df["strategy"].isin(_CONTROL_VALUES)]
+
+
+# ---------------------------------------------------------------------------
+# Per-cell aggregation under a scoring convention
+# ---------------------------------------------------------------------------
+
+
+def _apply_convention(
+    df: "pd.DataFrame", convention: ScoringConvention
+) -> "pd.DataFrame":
+    """
+    Resolve the primary DV per the scoring convention, on the raw per-run
+    frame, before aggregation.
+
+    ``intent_to_treat`` keeps every experimental run and rewrites the primary
+    DV to 0.0 for any run that failed (no metric row, so ``entity_id_f1`` is
+    NaN) or whose diagram did not parse (``parses_valid`` is 0). Note the two
+    are distinct: a run can parse-fail yet still carry a partial ``entity_id_f1``
+    from the scorer, so a coalesce of NaN alone would leave those unrenderable
+    diagrams at their partial score. Both are zeroed here.
+
+    ``valid_only`` drops every run that did not parse (``parses_valid`` != 1),
+    which also drops outright failures (their ``parses_valid`` is NaN).
+    """
+    out = df.copy()
+    parses = out["parses_valid"]
+    if convention == INTENT_TO_TREAT:
+        # A run counts as scorable only if it parsed. Anything else (failed
+        # run with NaN parses_valid, or a parsed-invalid diagram) is 0.0.
+        scored = out[PRIMARY_DV].where(parses == 1, other=0.0)
+        # A parsed run with a NaN DV should not exist, but guard anyway so a
+        # stray NaN never survives into the aggregate as a silent drop.
+        out[PRIMARY_DV] = scored.fillna(0.0)
+        return out
+    # valid_only: keep parsed runs only. NaN parses_valid (failures) compare
+    # false and are dropped, which is the intended exclusion.
+    return out[parses == 1]
+
+
+def aggregate_experimental(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> "pd.DataFrame":
+    """
+    Collapse the experimental rows to one observation per cell for the
+    inferential tests: filter to experimental, apply the scoring convention,
+    then average the DVs across the repeats of each
+    (strategy, model, example_id) cell.
+
+    ``tier`` is carried along unchanged (it is constant within a cell, being a
+    function of example_id). Under ``intent_to_treat`` every experimental cell
+    survives, because failures contribute a 0.0 rather than dropping out;
+    under ``valid_only`` a cell with no parsed run disappears entirely, which
+    is the honest outcome (there is nothing to average).
+
+    Returns an empty frame unchanged (callers guard on emptiness).
+    """
+    import pandas as pd  # noqa: F401
+
+    exp = _experimental(df)
+    if exp.empty:
+        return exp
+    scored = _apply_convention(exp, convention)
+    if scored.empty:
+        return scored
+
+    # Average the numeric DVs the inferential and effect-size code consume.
+    # tier rides along via a stable per-cell first value (constant in a cell).
+    dv_cols = [PRIMARY_DV, *EFFICIENCY_DVS]
+    present = [c for c in dv_cols if c in scored.columns]
+    agg = (
+        scored.groupby(list(_CELL_KEYS), dropna=False)
+        .agg({**{c: "mean" for c in present}, "tier": "first"})
+        .reset_index()
+    )
+    return agg
 
 
 # ---------------------------------------------------------------------------
@@ -222,11 +351,17 @@ def _anova(
     *,
     dv: str = PRIMARY_DV,
     term_of_interest: str | None = None,
+    convention: ScoringConvention = DEFAULT_CONVENTION,
 ) -> dict[str, Any]:
     """
-    Fit an OLS model ``dv ~ C(f1) [* C(f2) ...]`` on the experimental
-    (non-control) rows and run a Type-II ANOVA, returning F / p / df and
-    partial η² per term.
+    Fit an OLS model ``dv ~ C(f1) [* C(f2) ...]`` on the per-cell aggregated
+    frame (one mean per strategy×model×input under ``convention``) and run a
+    Type-II ANOVA, returning F / p / df and partial η² per term.
+
+    Aggregating before the fit is deliberate: the repeats are technical
+    replicates, so fitting the raw rows would be pseudoreplication and
+    overstate significance. ``n`` in the result is therefore the number of
+    cells, not the number of runs.
 
     ``factors`` of length 2 are crossed with ``*`` so the interaction term
     is included: that interaction is the quantity of interest for the
@@ -236,8 +371,8 @@ def _anova(
 
     Returns a skip-stub (never raises) when any factor is under-leveled.
     """
-    exp = _experimental(df)
-    guard = _guard_factors(exp, factors)
+    agg = aggregate_experimental(df, convention)
+    guard = _guard_factors(agg, factors)
 
     base_meta: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -249,6 +384,8 @@ def _anova(
         if "strategy" in factors
         else None,
         "excludes_controls": True,
+        "unit_of_analysis": "mean over repeats per (strategy, model, input)",
+        "scoring_convention": convention,
     }
     if guard is not None:
         return {**base_meta, **guard}
@@ -269,7 +406,7 @@ def _anova(
     rhs = " * ".join(terms)
     formula = f"{dv} ~ {rhs}"
 
-    model = ols(formula, data=exp).fit()
+    model = ols(formula, data=agg).fit()
     # Type II is the conventional choice for unbalanced factorial designs
     # without a strong a-priori ordering of effects.
     table = sm.stats.anova_lm(model, typ=2)
@@ -296,22 +433,27 @@ def _anova(
     return {
         **base_meta,
         "status": "ok",
-        "n": int(len(exp)),
+        "n": int(len(agg)),
         "residual_df": _to_native(table.loc["Residual", "df"]),
         "terms": results,
     }
 
 
-def anova_strategy(df: "pd.DataFrame") -> dict[str, Any]:
+def anova_strategy(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
     """One-way ANOVA: correctness ~ strategy (baseline = single_agent)."""
     return _anova(
         df,
         ["strategy"],
         term_of_interest="C(strategy, Treatment(reference='single_agent'))",
+        convention=convention,
     )
 
 
-def anova_strategy_by_tier(df: "pd.DataFrame") -> dict[str, Any]:
+def anova_strategy_by_tier(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
     """
     Two-way ANOVA: correctness ~ strategy × tier. The interaction term is
     the quantity of interest (does input complexity moderate the effect).
@@ -321,10 +463,13 @@ def anova_strategy_by_tier(df: "pd.DataFrame") -> dict[str, Any]:
         df,
         ["strategy", "tier"],
         term_of_interest=("C(strategy, Treatment(reference='single_agent')):C(tier)"),
+        convention=convention,
     )
 
 
-def anova_strategy_by_model(df: "pd.DataFrame") -> dict[str, Any]:
+def anova_strategy_by_model(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
     """
     Two-way ANOVA: correctness ~ strategy × model. The interaction probes
     whether the strategy effect holds across models / providers: a
@@ -334,6 +479,7 @@ def anova_strategy_by_model(df: "pd.DataFrame") -> dict[str, Any]:
         df,
         ["strategy", "model"],
         term_of_interest=("C(strategy, Treatment(reference='single_agent')):C(model)"),
+        convention=convention,
     )
 
 
@@ -342,29 +488,34 @@ def anova_strategy_by_model(df: "pd.DataFrame") -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def posthoc_strategy(df: "pd.DataFrame") -> dict[str, Any]:
+def posthoc_strategy(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
     """
-    Tukey HSD pairwise comparison of strategies on the primary DV. Run
-    regardless of ANOVA significance for completeness; the consumer decides
-    whether to report it (convention: only when the omnibus ANOVA is
-    significant). Self-skips when fewer than two strategies are present.
+    Tukey HSD pairwise comparison of strategies on the primary DV, on the
+    per-cell aggregated frame. Run regardless of ANOVA significance for
+    completeness; the consumer decides whether to report it (convention: only
+    when the omnibus ANOVA is significant). Self-skips when fewer than two
+    strategies are present.
     """
-    exp = _experimental(df)
+    agg = aggregate_experimental(df, convention)
     base_meta: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "analysis": "posthoc_tukey_hsd",
         "dependent_variable": PRIMARY_DV,
         "factor": "strategy",
+        "unit_of_analysis": "mean over repeats per (strategy, model, input)",
+        "scoring_convention": convention,
     }
-    guard = _guard_factors(exp, ["strategy"])
+    guard = _guard_factors(agg, ["strategy"])
     if guard is not None:
         return {**base_meta, **guard}
 
     from statsmodels.stats.multicomp import pairwise_tukeyhsd
 
     tukey = pairwise_tukeyhsd(
-        endog=exp[PRIMARY_DV].astype(float),
-        groups=exp["strategy"].astype(str),
+        endog=agg[PRIMARY_DV].astype(float),
+        groups=agg["strategy"].astype(str),
         alpha=0.05,
     )
     # Build the comparison rows from the *public* TukeyHSDResults attributes
@@ -396,7 +547,7 @@ def posthoc_strategy(df: "pd.DataFrame") -> dict[str, Any]:
     return {
         **base_meta,
         "status": "ok",
-        "n": int(len(exp)),
+        "n": int(len(agg)),
         "alpha": 0.05,
         "comparisons": comparisons,
     }
@@ -407,28 +558,32 @@ def posthoc_strategy(df: "pd.DataFrame") -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def effect_sizes(df: "pd.DataFrame") -> dict[str, Any]:
+def effect_sizes(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
     """
     Cohen's d for every pairwise strategy contrast on the primary DV, using
-    a pooled standard deviation. Partial η² for the overall effects is
-    reported within each ANOVA file; here we provide the pairwise d that
-    the strategy comparison narrative needs.
+    a pooled standard deviation, on the per-cell aggregated frame. Partial η²
+    for the overall effects is reported within each ANOVA file; here we
+    provide the pairwise d that the strategy comparison narrative needs.
     """
-    exp = _experimental(df)
+    agg = aggregate_experimental(df, convention)
     out: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "analysis": "effect_sizes",
         "dependent_variable": PRIMARY_DV,
         "measure": "cohens_d_pairwise",
+        "unit_of_analysis": "mean over repeats per (strategy, model, input)",
+        "scoring_convention": convention,
         "pairs": [],
     }
-    guard = _guard_factors(exp, ["strategy"])
+    guard = _guard_factors(agg, ["strategy"])
     if guard is not None:
         return {**out, **guard}
 
     groups = {
         str(name): grp[PRIMARY_DV].dropna().astype(float)
-        for name, grp in exp.groupby("strategy")
+        for name, grp in agg.groupby("strategy")
     }
     names = sorted(groups)
     for i in range(len(names)):
@@ -487,6 +642,120 @@ def _cohens_d(a, b) -> float | str | None:
         # from "not computed").
         return "inf" if mean_diff > 0 else "-inf"
     return _to_native(mean_diff / (pooled**0.5))
+
+
+# ---------------------------------------------------------------------------
+# Mixed-effects robustness model
+# ---------------------------------------------------------------------------
+
+
+def mixed_effects_robustness(
+    df: "pd.DataFrame", convention: ScoringConvention = DEFAULT_CONVENTION
+) -> dict[str, Any]:
+    """
+    Robustness check on the aggregated ANOVA: a linear mixed model
+    ``entity_id_f1 ~ strategy * tier`` fit on the un-aggregated experimental
+    runs, with crossed random intercepts for model and input.
+
+    The aggregated ANOVA removes the repeat correlation by pre-averaging, but
+    the resulting cells still share structure: every cell on a strong model
+    is lifted, every cell on a hard input is dragged down. This model accounts
+    for that crossed grouping directly (model and example_id as random
+    effects) instead of by averaging, so agreement between the two is evidence
+    the strategy conclusion is not an artifact of the simpler error model.
+
+    Crossed (non-nested) random effects in statsmodels go through the
+    ``vc_formula`` variance-components mechanism on a single dummy grouping
+    column, and can fail to converge. This is a secondary check, so on any
+    failure it degrades to a skip-stub (never raises), matching the
+    ``_guard_factors`` contract used elsewhere.
+    """
+    base_meta: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "analysis": "mixed_effects_robustness",
+        "dependent_variable": PRIMARY_DV,
+        "fixed_effects": "strategy * tier",
+        "random_effects": ["model", "example_id"],
+        "unit_of_analysis": "per-run (un-aggregated); repeats modeled, not averaged",
+        "scoring_convention": convention,
+        "role": "robustness_check",
+    }
+
+    # Apply the convention on the raw experimental rows, but do NOT aggregate:
+    # the mixed model wants one row per run so the random effects have within
+    # cell replication to estimate from.
+    exp = _experimental(df)
+    if exp.empty:
+        return {**base_meta, "status": "skipped", "reason": "no experimental rows"}
+    scored = _apply_convention(exp, convention)
+
+    # tier must vary for the strategy*tier fixed effect to be estimable, and
+    # both grouping factors must have spread for the random effects.
+    guard = _guard_factors(scored, ["strategy", "tier"])
+    if guard is not None:
+        return {**base_meta, **guard}
+
+    try:
+        import warnings
+
+        import statsmodels.formula.api as smf
+        from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+        data = scored.copy()
+        # A single constant grouping column lets both model and example_id
+        # enter as variance components, giving crossed (not nested) effects.
+        data["_grp"] = 1
+        vc = {"model": "0 + C(model)", "example_id": "0 + C(example_id)"}
+        md = smf.mixedlm(
+            f"{PRIMARY_DV} ~ C(strategy, Treatment(reference={BASELINE_STRATEGY!r})) "
+            "* C(tier)",
+            data=data,
+            groups=data["_grp"],
+            vc_formula=vc,
+        )
+        # Non-convergence is handled below via fit.converged and reported as a
+        # skip-stub; the warnings it emits along the way are noise here, so
+        # silence them rather than letting them clutter the run log.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ConvergenceWarning)
+            fit = md.fit()
+    except Exception as exc:  # noqa: BLE001 - robustness check, never fatal
+        # Non-convergence, singular design, or a statsmodels internal error all
+        # land here: report the reason honestly rather than aborting the run.
+        return {
+            **base_meta,
+            "status": "skipped",
+            "reason": f"mixed model did not fit: {type(exc).__name__}: {exc}",
+        }
+
+    if not getattr(fit, "converged", True):
+        return {**base_meta, "status": "skipped", "reason": "did not converge"}
+
+    # Report the fixed-effect coefficients (the strategy/tier terms) with their
+    # standard errors and p-values; the random-effect variances go alongside.
+    params = fit.params
+    fixed = {}
+    for name in params.index:
+        # Skip the variance-component parameters (their names carry "Var").
+        if "Var" in name or name == "Group Var":
+            continue
+        fixed[name] = {
+            "coef": _to_native(params[name]),
+            "std_err": _to_native(fit.bse.get(name)),
+            "p": _to_native(fit.pvalues.get(name)),
+        }
+
+    return {
+        **base_meta,
+        "status": "ok",
+        "n": int(len(scored)),
+        "n_groups": {
+            "model": int(scored["model"].nunique()),
+            "example_id": int(scored["example_id"].nunique()),
+        },
+        "fixed_effects_estimates": fixed,
+        "converged": bool(getattr(fit, "converged", True)),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/maestro/analysis/statistics.py
+++ b/src/maestro/analysis/statistics.py
@@ -198,6 +198,16 @@ def _apply_convention(
     ``valid_only`` drops every run that did not parse (``parses_valid`` != 1),
     which also drops outright failures (their ``parses_valid`` is NaN).
     """
+    # Reject an unrecognized convention rather than letting it fall through to
+    # the valid_only branch: this is a scoring contract, and silently scoring
+    # under the wrong rule is exactly the kind of quiet mislabeling the project
+    # forbids. A caller passing a bad literal is a programmer error, so raise.
+    if convention not in (INTENT_TO_TREAT, VALID_ONLY):
+        raise ValueError(
+            f"unknown scoring convention {convention!r}; "
+            f"expected {INTENT_TO_TREAT!r} or {VALID_ONLY!r}"
+        )
+
     out = df.copy()
     parses = out["parses_valid"]
     if convention == INTENT_TO_TREAT:
@@ -407,6 +417,22 @@ def _anova(
     formula = f"{dv} ~ {rhs}"
 
     model = ols(formula, data=agg).fit()
+    # A saturated model (one observation per parameter) leaves zero residual
+    # degrees of freedom, so every F is a 0/0 division that surfaces as inf or
+    # NaN and would then be flattened to null in a misleading status "ok"
+    # result. That is uncomputable, not a real fit: skip it honestly, the same
+    # way an under-leveled factor is skipped. It happens on a sparse corpus
+    # where the cells barely outnumber the model terms.
+    if model.df_resid <= 0:
+        return {
+            **base_meta,
+            "status": "skipped",
+            "reason": (
+                "model is saturated (zero residual degrees of freedom): "
+                f"{int(model.nobs)} cells for {int(model.df_model) + 1} terms"
+            ),
+        }
+
     # Type II is the conventional choice for unbalanced factorial designs
     # without a strong a-priori ordering of effects.
     table = sm.stats.anova_lm(model, typ=2)
@@ -689,9 +715,13 @@ def mixed_effects_robustness(
         return {**base_meta, "status": "skipped", "reason": "no experimental rows"}
     scored = _apply_convention(exp, convention)
 
-    # tier must vary for the strategy*tier fixed effect to be estimable, and
-    # both grouping factors must have spread for the random effects.
-    guard = _guard_factors(scored, ["strategy", "tier"])
+    # strategy and tier must vary for the strategy*tier fixed effect to be
+    # estimable, and both random-effect grouping factors (model, example_id)
+    # need >= 2 levels for their variance components to mean anything. Guard
+    # all four up front so a single-level grouping factor yields an honest
+    # skip-stub instead of falling into the fitter and being reported as a
+    # generic non-convergence.
+    guard = _guard_factors(scored, ["strategy", "tier", "model", "example_id"])
     if guard is not None:
         return {**base_meta, **guard}
 

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -252,8 +252,13 @@ def fetch_analysis_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     for traceability. ``parses_valid`` rides along for structural-validity
     breakdowns.
 
-    An INNER join means runs without a metric row (e.g. a failed run that
-    never got scored) are excluded: analysis operates on scored runs only.
+    The metric join is a LEFT join on purpose: a run that failed outright
+    never got a ``metric_results`` row, and the intent-to-treat scoring
+    convention needs those failures present (scored 0.0), not silently
+    dropped. Such rows come back with every ``m.*`` column NULL; the
+    analysis layer decides how to treat them per scoring convention. The
+    ``run_results`` join stays INNER because a config without a result row
+    is not a run that happened.
     """
     return conn.execute(
         """
@@ -283,7 +288,7 @@ def fetch_analysis_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
             m.duplicate_relationships AS duplicate_relationships
         FROM run_configs c
         JOIN run_results r ON c.run_id = r.run_id
-        JOIN metric_results m ON c.run_id = m.run_id
+        LEFT JOIN metric_results m ON c.run_id = m.run_id
         ORDER BY c.timestamp
         """,
     ).fetchall()

--- a/src/maestro/db/queries.py
+++ b/src/maestro/db/queries.py
@@ -234,8 +234,10 @@ def fetch_all_results(conn: sqlite3.Connection) -> list[sqlite3.Row]:
 
 def fetch_analysis_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     """
-    Three-way join (run_configs ⋈ run_results ⋈ metric_results) yielding
-    one row per metriced run, for the statistical analysis pipeline.
+    Three-way join (run_configs ⋈ run_results, then LEFT ⋈ metric_results)
+    yielding one row per completed run, for the statistical analysis pipeline.
+    The metric columns are nullable: a run with no ``metric_results`` row (an
+    outright failure) still appears, with every ``m.*`` column NULL.
 
     Read-only. Columns are listed *explicitly* rather than via ``c.*, r.*,
     m.*`` on purpose: all three tables carry a ``run_id`` column, and a

--- a/tests/analysis/test_statistics.py
+++ b/tests/analysis/test_statistics.py
@@ -192,6 +192,28 @@ def _populate_two_levels(conn: sqlite3.Connection) -> None:
     )
 
 
+def _populate_two_tiers(conn: sqlite3.Connection) -> None:
+    """
+    Extend the two-level fixture with a second tier so the mixed model's
+    strategy*tier fixed effect is estimable and the four-factor guard
+    (strategy, tier, model, example_id) is cleared. Used by the mixed-effects
+    tests that need to reach the fitter.
+    """
+    _populate_two_levels(conn)  # tier COMPLEX
+    for model in ("model_a", "model_b"):
+        for strategy in _EXPERIMENTAL:
+            for run_number, delta in enumerate([-0.05, 0.0, 0.05], start=1):
+                _insert_cell(
+                    conn,
+                    strategy=strategy,
+                    model=model,
+                    tier=Tier.SIMPLE,
+                    run_number=run_number,
+                    example_id="ex_simple",
+                    f1=0.5 + delta,
+                )
+
+
 # ---------------------------------------------------------------------------
 # load_dataframe
 # ---------------------------------------------------------------------------
@@ -429,6 +451,42 @@ def test_valid_only_convention_recorded_in_metadata():
     assert out["scoring_convention"] == "valid_only"
 
 
+def test_unknown_convention_rejected():
+    """An unrecognized convention is a programmer error, raised not swallowed."""
+    conn = _conn()
+    _populate_two_levels(conn)
+    df = stats.load_dataframe(conn)
+    with pytest.raises(ValueError, match="unknown scoring convention"):
+        stats.aggregate_experimental(df, "not_a_convention")  # type: ignore[arg-type]
+
+
+def test_anova_skips_on_saturated_model():
+    """
+    A cell count that barely exceeds the term count leaves zero residual df:
+    the ANOVA is uncomputable and must skip, not emit a status ok with null
+    F/p. Build a single input per model so strategy x model saturates: with one
+    input, each (strategy, model) cell is a single observation and the crossed
+    model has as many parameters as observations.
+    """
+    conn = _conn()
+    models = ["model_a", "model_b"]
+    for model in models:
+        for strategy in _EXPERIMENTAL:
+            _insert_cell(
+                conn,
+                strategy=strategy,
+                model=model,
+                tier=Tier.COMPLEX,
+                run_number=1,
+                example_id="ex_only",
+                f1=0.6,
+            )
+    df = stats.load_dataframe(conn)
+    out = stats.anova_strategy_by_model(df, stats.INTENT_TO_TREAT)
+    assert out["status"] == "skipped"
+    assert "saturated" in out["reason"]
+
+
 # ---------------------------------------------------------------------------
 # Mixed-effects robustness model
 # ---------------------------------------------------------------------------
@@ -442,32 +500,22 @@ def test_mixed_effects_returns_result_or_skip_stub():
     strategy*tier term, so build a two-tier corpus.
     """
     conn = _conn()
-    _populate_two_levels(conn)  # tier COMPLEX
-    # Add a second tier so strategy*tier is estimable.
-    for model in ("model_a", "model_b"):
-        for strategy in _EXPERIMENTAL:
-            for run_number, delta in enumerate([-0.05, 0.0, 0.05], start=1):
-                _insert_cell(
-                    conn,
-                    strategy=strategy,
-                    model=model,
-                    tier=Tier.SIMPLE,
-                    run_number=run_number,
-                    example_id="ex_simple",
-                    f1=0.5 + delta,
-                )
+    _populate_two_tiers(conn)
     df = stats.load_dataframe(conn)
     out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
 
     assert out["analysis"] == "mixed_effects_robustness"
     assert out["role"] == "robustness_check"
+    # Either branch is valid on this small synthetic fixture (crossed random
+    # effects can genuinely fail to converge here); the deterministic ok/skip
+    # branches are asserted exactly in the monkeypatched tests below. What must
+    # always hold: a self-describing status and strict-JSON serializability.
     assert out["status"] in {"ok", "skipped"}
     if out["status"] == "ok":
         assert out["fixed_effects_estimates"]
         assert out["scoring_convention"] == "intent_to_treat"
     else:
         assert "reason" in out
-    # Must be strict-JSON serializable regardless of branch.
     import json
 
     json.dumps(out, allow_nan=False)
@@ -480,6 +528,57 @@ def test_mixed_effects_skips_on_single_tier():
     df = stats.load_dataframe(conn)
     out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
     assert out["status"] == "skipped"
+    # The skip must name the offending factor, not just report a generic
+    # failure: tier is the one with a single level here.
+    assert out.get("factor") == "tier"
+    assert "tier" in out["reason"]
+
+
+def test_mixed_effects_skips_on_fit_exception(monkeypatch):
+    """
+    A raised exception inside the fitter (not just non-convergence) degrades to
+    a skip-stub whose reason names the exception, never propagating. Force it by
+    monkeypatching mixedlm to raise, on a corpus that clears the factor guard.
+    """
+    conn = _conn()
+    _populate_two_tiers(conn)
+    df = stats.load_dataframe(conn)
+
+    import statsmodels.formula.api as smf
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("synthetic fit failure")
+
+    monkeypatch.setattr(smf, "mixedlm", _boom)
+    out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
+    assert out["status"] == "skipped"
+    assert "RuntimeError" in out["reason"]
+    assert "synthetic fit failure" in out["reason"]
+
+
+def test_mixed_effects_skips_on_non_convergence(monkeypatch):
+    """
+    A model that fits but does not converge is reported as skipped, not ok:
+    a non-converged estimate is not a result we stand behind. Stub the fit to
+    return an object flagged not-converged.
+    """
+    conn = _conn()
+    _populate_two_tiers(conn)
+    df = stats.load_dataframe(conn)
+
+    import statsmodels.formula.api as smf
+
+    class _Fit:
+        converged = False
+
+    class _Model:
+        def fit(self, *args, **kwargs):
+            return _Fit()
+
+    monkeypatch.setattr(smf, "mixedlm", lambda *a, **k: _Model())
+    out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
+    assert out["status"] == "skipped"
+    assert "converge" in out["reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/analysis/test_statistics.py
+++ b/tests/analysis/test_statistics.py
@@ -97,10 +97,19 @@ def _insert_cell(
     tier: Tier,
     run_number: int,
     f1: float,
+    example_id: str = "ex_01",
     cost: float = 0.001,
     duration_ms: int = 100,
+    parses_valid: bool = True,
+    metric: bool = True,
 ) -> None:
-    """Insert one config+result+metric triple for a single run."""
+    """
+    Insert one config+result(+metric) triple for a single run.
+
+    ``metric=False`` inserts the run WITHOUT a metric_results row, mirroring an
+    outright failure: the LEFT join in fetch_analysis_rows surfaces it with
+    NULL metrics, which the intent_to_treat convention scores as 0.0.
+    """
     run_id = uuid.uuid4()
     insert_run_config(
         conn,
@@ -108,7 +117,7 @@ def _insert_cell(
             run_id=run_id,
             strategy=strategy,
             model=model,
-            example_id="ex_01",
+            example_id=example_id,
             tier=tier,
             run_number=run_number,
         ),
@@ -125,7 +134,10 @@ def _insert_cell(
             error=None,
         ),
     )
+    if not metric:
+        return
     fields = _zeroed_metric_fields()
+    fields["parses_valid"] = parses_valid
     fields["entity_id_f1"] = f1
     insert_metric_result(
         conn,
@@ -133,11 +145,18 @@ def _insert_cell(
     )
 
 
+# Two inputs and two models per strategy, so per-cell aggregation still leaves
+# enough cells (2 models x 2 inputs x 3 strategies = 12) for a saturated
+# strategy x model ANOVA to have residual degrees of freedom. A single input
+# would collapse to 6 cells and zero residual df after averaging.
+_EXAMPLES = ("ex_01", "ex_02")
+
+
 def _populate_two_levels(conn: sqlite3.Connection) -> None:
     """
-    Two models, three experimental strategies, several repeats, single tier:
-    mirrors the real dev DB (model varies, tier does not). F1 values are
-    spread so the ANOVA has variance to find.
+    Two models, two inputs, three experimental strategies, several repeats,
+    single tier: mirrors the real dev DB (model and input vary, tier does not).
+    F1 values are spread so the ANOVA has variance to find.
     """
     models = ["model_a", "model_b"]
     f1_by_strategy = {
@@ -146,18 +165,20 @@ def _populate_two_levels(conn: sqlite3.Connection) -> None:
         Strategy.LANG_GRAPH: 0.90,
     }
     for model in models:
-        for strategy in _EXPERIMENTAL:
-            base = f1_by_strategy[strategy]
-            for run_number, delta in enumerate([-0.05, 0.0, 0.05], start=1):
-                _insert_cell(
-                    conn,
-                    strategy=strategy,
-                    model=model,
-                    tier=Tier.COMPLEX,
-                    run_number=run_number,
-                    f1=base + delta,
-                    cost=0.001 if strategy is Strategy.SINGLE_AGENT else 0.005,
-                )
+        for example_id in _EXAMPLES:
+            for strategy in _EXPERIMENTAL:
+                base = f1_by_strategy[strategy]
+                for run_number, delta in enumerate([-0.05, 0.0, 0.05], start=1):
+                    _insert_cell(
+                        conn,
+                        strategy=strategy,
+                        model=model,
+                        tier=Tier.COMPLEX,
+                        run_number=run_number,
+                        example_id=example_id,
+                        f1=base + delta,
+                        cost=0.001 if strategy is Strategy.SINGLE_AGENT else 0.005,
+                    )
     # A control cell: floor F1 = 0. Present for descriptives, must be
     # excluded from ANOVA / effect sizes.
     _insert_cell(
@@ -180,8 +201,8 @@ def test_load_dataframe_shape():
     conn = _conn()
     _populate_two_levels(conn)
     df = stats.load_dataframe(conn)
-    # 2 models * 3 strategies * 3 repeats + 1 control = 19 rows.
-    assert len(df) == 19
+    # 2 models * 2 inputs * 3 strategies * 3 repeats + 1 control = 37 rows.
+    assert len(df) == 37
     assert stats.PRIMARY_DV in df.columns
     assert {"strategy", "model", "tier", "cost_usd", "duration_ms"} <= set(df.columns)
 
@@ -234,8 +255,12 @@ def test_anova_strategy_ok_and_excludes_controls():
     assert out["status"] == "ok"
     assert out["excludes_controls"] is True
     assert out["reference_level"] == {"strategy": "single_agent"}
-    # n must be the experimental rows only: 18, not 19 (control dropped).
-    assert out["n"] == 18
+    # n is the aggregated CELL count, not the raw run count: the inferential
+    # path averages the repeats first. 2 models x 2 inputs x 3 strategies = 12
+    # cells (the 36 experimental runs and the 1 control run collapse away).
+    assert out["n"] == 12
+    assert out["unit_of_analysis"] == "mean over repeats per (strategy, model, input)"
+    assert out["scoring_convention"] == stats.INTENT_TO_TREAT
     # The strategy term (looked up by name, not by dict order) must carry a
     # finite F and partial η².
     assert out["terms"]
@@ -279,6 +304,182 @@ def test_anova_skips_on_empty_db():
     out = stats.anova_strategy(df)
     assert out["status"] == "skipped"
     assert "no experimental rows" in out["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Aggregation grain & scoring conventions
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_grain_one_row_per_cell():
+    """
+    Aggregation yields exactly one row per (strategy, model, input): the repeats
+    collapse. The fixture has 2 models x 2 inputs x 3 strategies = 12 cells.
+    """
+    conn = _conn()
+    _populate_two_levels(conn)
+    df = stats.load_dataframe(conn)
+    agg = stats.aggregate_experimental(df, stats.INTENT_TO_TREAT)
+    assert len(agg) == 12
+    # One row per cell: no (strategy, model, example_id) key repeats.
+    assert not agg.duplicated(["strategy", "model", "example_id"]).any()
+    # Controls never enter the aggregated (inferential) frame.
+    assert _CONTROL.value not in set(agg["strategy"])
+
+
+def test_intent_to_treat_scores_failures_and_invalid_as_zero():
+    """
+    Under intent_to_treat a run with no metric row (outright failure) and a run
+    whose diagram did not parse both contribute 0.0; under valid_only both are
+    excluded. Build one cell (single strategy/model/input) whose three repeats
+    are: one good (0.9, valid), one parse-invalid (0.8 but parses_valid=0), one
+    outright failure (no metric row).
+    """
+    conn = _conn()
+    _insert_cell(
+        conn,
+        strategy=Strategy.CREW_AI,
+        model="m",
+        tier=Tier.COMPLEX,
+        run_number=1,
+        f1=0.9,
+        parses_valid=True,
+    )
+    _insert_cell(
+        conn,
+        strategy=Strategy.CREW_AI,
+        model="m",
+        tier=Tier.COMPLEX,
+        run_number=2,
+        f1=0.8,  # scorer produced a partial F1 even though it did not render
+        parses_valid=False,
+    )
+    _insert_cell(
+        conn,
+        strategy=Strategy.CREW_AI,
+        model="m",
+        tier=Tier.COMPLEX,
+        run_number=3,
+        f1=0.0,
+        metric=False,  # outright failure: no metric_results row at all
+    )
+    df = stats.load_dataframe(conn)
+
+    itt = stats.aggregate_experimental(df, stats.INTENT_TO_TREAT)
+    # One surviving cell; mean over [0.9, 0.0, 0.0] = 0.3.
+    assert len(itt) == 1
+    assert itt.iloc[0][stats.PRIMARY_DV] == pytest.approx(0.3)
+
+    valid = stats.aggregate_experimental(df, stats.VALID_ONLY)
+    # Only the single valid run survives; mean = 0.9.
+    assert len(valid) == 1
+    assert valid.iloc[0][stats.PRIMARY_DV] == pytest.approx(0.9)
+
+
+def test_valid_only_drops_cell_with_no_valid_run():
+    """
+    A cell whose every run is invalid/failed has nothing to average under
+    valid_only and disappears; under intent_to_treat it survives at 0.0.
+    """
+    conn = _conn()
+    _insert_cell(
+        conn,
+        strategy=Strategy.CREW_AI,
+        model="m",
+        tier=Tier.COMPLEX,
+        run_number=1,
+        f1=0.7,
+        parses_valid=False,
+    )
+    _insert_cell(
+        conn,
+        strategy=Strategy.CREW_AI,
+        model="m",
+        tier=Tier.COMPLEX,
+        run_number=2,
+        f1=0.0,
+        metric=False,
+    )
+    df = stats.load_dataframe(conn)
+
+    assert len(stats.aggregate_experimental(df, stats.VALID_ONLY)) == 0
+    itt = stats.aggregate_experimental(df, stats.INTENT_TO_TREAT)
+    assert len(itt) == 1
+    assert itt.iloc[0][stats.PRIMARY_DV] == 0.0
+
+
+def test_anova_n_matches_aggregated_not_raw():
+    """The fitted ANOVA reports the aggregated cell count, never the raw runs."""
+    conn = _conn()
+    _populate_two_levels(conn)
+    df = stats.load_dataframe(conn)
+    agg = stats.aggregate_experimental(df, stats.INTENT_TO_TREAT)
+    out = stats.anova_strategy(df, stats.INTENT_TO_TREAT)
+    assert out["n"] == len(agg)
+    # And that is far below the 36 experimental raw rows.
+    assert out["n"] == 12
+    assert len(stats._experimental(df)) == 36
+
+
+def test_valid_only_convention_recorded_in_metadata():
+    conn = _conn()
+    _populate_two_levels(conn)
+    df = stats.load_dataframe(conn)
+    out = stats.anova_strategy(df, stats.VALID_ONLY)
+    assert out["scoring_convention"] == "valid_only"
+
+
+# ---------------------------------------------------------------------------
+# Mixed-effects robustness model
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_effects_returns_result_or_skip_stub():
+    """
+    The mixed model either fits (status ok, with fixed-effect estimates) or
+    degrades to a skip-stub (status skipped, with a reason). Either is a valid,
+    self-describing output: it must never raise. Needs >= 2 tiers for the
+    strategy*tier term, so build a two-tier corpus.
+    """
+    conn = _conn()
+    _populate_two_levels(conn)  # tier COMPLEX
+    # Add a second tier so strategy*tier is estimable.
+    for model in ("model_a", "model_b"):
+        for strategy in _EXPERIMENTAL:
+            for run_number, delta in enumerate([-0.05, 0.0, 0.05], start=1):
+                _insert_cell(
+                    conn,
+                    strategy=strategy,
+                    model=model,
+                    tier=Tier.SIMPLE,
+                    run_number=run_number,
+                    example_id="ex_simple",
+                    f1=0.5 + delta,
+                )
+    df = stats.load_dataframe(conn)
+    out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
+
+    assert out["analysis"] == "mixed_effects_robustness"
+    assert out["role"] == "robustness_check"
+    assert out["status"] in {"ok", "skipped"}
+    if out["status"] == "ok":
+        assert out["fixed_effects_estimates"]
+        assert out["scoring_convention"] == "intent_to_treat"
+    else:
+        assert "reason" in out
+    # Must be strict-JSON serializable regardless of branch.
+    import json
+
+    json.dumps(out, allow_nan=False)
+
+
+def test_mixed_effects_skips_on_single_tier():
+    """Single tier -> strategy*tier not estimable -> graceful skip-stub."""
+    conn = _conn()
+    _populate_two_levels(conn)  # all COMPLEX
+    df = stats.load_dataframe(conn)
+    out = stats.mixed_effects_robustness(df, stats.INTENT_TO_TREAT)
+    assert out["status"] == "skipped"
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +580,42 @@ def test_all_outputs_json_serializable():
 # ---------------------------------------------------------------------------
 
 
+def _analysis_frame(score_by_strategy: dict[Strategy, float]) -> "object":
+    """
+    Build a load_dataframe-shaped frame where each strategy scores an
+    identical value across three cells (distinct model x input), all valid.
+
+    After per-cell aggregation each strategy still has three cells at the same
+    mean, so pooled within-strategy variance stays zero: the Cohen's d
+    zero-variance edge case survives the aggregation step. The columns match
+    what aggregate_experimental reads (strategy, model, example_id, tier,
+    parses_valid, the primary DV, and the efficiency DVs).
+    """
+    import pandas as pd
+
+    rows = []
+    for strat, score in score_by_strategy.items():
+        for model, example_id in (
+            ("m_a", "ex_01"),
+            ("m_b", "ex_02"),
+            ("m_c", "ex_03"),
+        ):
+            rows.append(
+                {
+                    "strategy": strat.value,
+                    "model": model,
+                    "example_id": example_id,
+                    "tier": 2,
+                    "parses_valid": 1,
+                    stats.PRIMARY_DV: score,
+                    "cost_usd": 0.001,
+                    "duration_ms": 100,
+                    "retry_count": 0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
 def test_cohens_d_zero_variance_unequal_means_is_infinite():
     """
     Two deterministic groups (zero within-group variance) at different score
@@ -387,19 +624,13 @@ def test_cohens_d_zero_variance_unequal_means_is_infinite():
     """
     import json
 
-    import pandas as pd
-
-    # Three strategies, every run identical within a strategy -> zero pooled
-    # variance for each pair, but the means differ.
-    rows = []
-    for strat, score in (
-        (Strategy.SINGLE_AGENT, 0.5),
-        (Strategy.CREW_AI, 0.9),
-        (Strategy.LANG_GRAPH, 0.1),
-    ):
-        for _ in range(3):
-            rows.append({"strategy": strat.value, stats.PRIMARY_DV: score})
-    df = pd.DataFrame(rows)
+    df = _analysis_frame(
+        {
+            Strategy.SINGLE_AGENT: 0.5,
+            Strategy.CREW_AI: 0.9,
+            Strategy.LANG_GRAPH: 0.1,
+        }
+    )
 
     out = stats.effect_sizes(df)
     assert out["status"] == "ok"
@@ -414,14 +645,12 @@ def test_cohens_d_zero_variance_unequal_means_is_infinite():
 
 
 def test_cohens_d_zero_variance_equal_means_is_zero():
-    import pandas as pd
-
-    rows = [
-        {"strategy": s.value, stats.PRIMARY_DV: 0.7}
-        for s in (Strategy.SINGLE_AGENT, Strategy.CREW_AI)
-        for _ in range(3)
-    ]
-    df = pd.DataFrame(rows)
+    df = _analysis_frame(
+        {
+            Strategy.SINGLE_AGENT: 0.7,
+            Strategy.CREW_AI: 0.7,
+        }
+    )
     out = stats.effect_sizes(df)
     assert out["pairs"][0]["cohens_d"] == 0.0
 
@@ -460,18 +689,29 @@ def test_cli_writes_output_contract(tmp_path):
     assert len(run_dirs) == 1
     run_dir = run_dirs[0]
 
-    # Required artifacts exist.
+    # Required artifacts exist. Convention-dependent analyses are emitted once
+    # per scoring convention as ``<stem>__<convention>.json``; the descriptive
+    # / taxonomy / trade-off outputs are convention-independent.
     assert (run_dir / "report.md").exists()
     assert (run_dir / "figures" / "README.md").exists()
+    convention_stems = (
+        "anova_strategy",
+        "anova_strategy_by_tier",
+        "anova_strategy_by_model",
+        "posthoc_strategy",
+        "effect_sizes",
+        "mixed_effects_robustness",
+    )
+    per_convention = [
+        f"{stem}__{conv}.json"
+        for stem in convention_stems
+        for conv in ("intent_to_treat", "valid_only")
+    ]
     for filename in (
         "descriptive.json",
-        "anova_strategy.json",
-        "anova_strategy_by_tier.json",
-        "anova_strategy_by_model.json",
-        "posthoc_strategy.json",
-        "effect_sizes.json",
         "error_taxonomy_by_strategy.json",
         "tradeoff_correctness_efficiency.json",
+        *per_convention,
     ):
         path = run_dir / filename
         assert path.exists(), f"missing output: {filename}"


### PR DESCRIPTION
- fetch_analysis_rows LEFT JOINs metric_results so outright failures reach the analysis layer and can be scored under intent_to_treat
- inferential path (anova, tukey, cohen's d) now fits per-cell means, one observation per (strategy, model, input), not the raw repeats
- add intent_to_treat / valid_only scoring conventions, emitted as per-convention output files with unit_of_analysis and scoring_convention recorded in metadata
- add mixed_effects_robustness (crossed random intercepts for model and input), degrading to a skip-stub on non-convergence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added intent-to-treat and valid-only scoring conventions for inferential analyses.
  - Added mixed-effects robustness analysis with safe “skipped” handling when data is insufficient.
  - Analysis outputs now include scoring convention and unit-of-analysis metadata.
  - Convention-dependent results are exported separately per convention, and the report reflects both.
- **Bug Fixes**
  - Previously unscored/failed runs are now retained (with missing metrics shown as null) instead of being dropped.
  - Inferential statistics now aggregate at the experimental cell level to prevent duplicate weighting.
- **Tests**
  - Expanded fixtures and assertions to cover convention behavior, aggregation grain, metadata, and robustness branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->