### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs when new commits land on the same PR; the latest
 # diff is the only one worth gating.
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/Colinho22/maestro/security/code-scanning/1](https://github.com/Colinho22/maestro/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained by least privilege regardless of repository/org defaults.

Best fix here (without changing functionality): define workflow-level permissions right after `on:` (or before `jobs:`) with only read access to repository contents:

- File: `.github/workflows/ci.yml`
- Add:
  - `permissions:`
  - `  contents: read`

This is sufficient for `actions/checkout` and the remaining lint/test steps. No additional imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to use read-only repository access.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->